### PR TITLE
otf support for LMDBs w/o edge information

### DIFF
--- a/ocpmodels/common/data_parallel.py
+++ b/ocpmodels/common/data_parallel.py
@@ -55,12 +55,13 @@ class OCPDataParallel(torch.nn.DataParallel):
 
 
 class ParallelCollater:
-    def __init__(self, num_gpus):
+    def __init__(self, num_gpus, otf_graph=False):
         self.num_gpus = num_gpus
+        self.otf_graph = otf_graph
 
     def __call__(self, data_list):
         if self.num_gpus == 1:
-            batch = data_list_collater(data_list)
+            batch = data_list_collater(data_list, otf_graph=self.otf_graph)
             return [batch]
 
         else:

--- a/ocpmodels/datasets/trajectory_lmdb.py
+++ b/ocpmodels/datasets/trajectory_lmdb.py
@@ -103,11 +103,18 @@ class TrajectoryLmdbDataset(Dataset):
         return env
 
 
-def data_list_collater(data_list):
-    n_neighbors = []
-    for i, data in enumerate(data_list):
-        n_index = data.edge_index[1, :]
-        n_neighbors.append(n_index.shape[0])
+def data_list_collater(data_list, otf_graph=False):
     batch = Batch.from_data_list(data_list)
-    batch.neighbors = torch.tensor(n_neighbors)
+
+    if not otf_graph:
+        try:
+            n_neighbors = []
+            for i, data in enumerate(data_list):
+                n_index = data.edge_index[1, :]
+                n_neighbors.append(n_index.shape[0])
+            batch.neighbors = torch.tensor(n_neighbors)
+        except NotImplementedError:
+            print(
+                "LMDB does not contain edge index information, set otf_graph=True"
+            )
     return batch

--- a/ocpmodels/models/cgcnn.py
+++ b/ocpmodels/models/cgcnn.py
@@ -106,9 +106,6 @@ class CGCNN(BaseModel):
         if self.embedding.device != data.atomic_numbers.device:
             self.embedding = self.embedding.to(data.atomic_numbers.device)
         data.x = self.embedding[data.atomic_numbers.long() - 1]
-        assert (
-            hasattr(data, "edge_index") or self.otf_graph
-        ), "LMDB does not contain edge indices, set self.otf_graph=True"
 
         pos = data.pos
         if self.regress_forces:

--- a/ocpmodels/models/dimenet.py
+++ b/ocpmodels/models/dimenet.py
@@ -105,9 +105,6 @@ class DimeNetWrap(DimeNet):
         if self.regress_forces:
             pos = pos.requires_grad_(True)
         batch = data.batch
-        assert (
-            hasattr(data, "edge_index") or self.otf_graph
-        ), "LMDB does not contain edge indices, set self.otf_graph=True"
 
         if self.otf_graph:
             edge_index, cell_offsets, neighbors = radius_graph_pbc(

--- a/ocpmodels/models/schnet.py
+++ b/ocpmodels/models/schnet.py
@@ -85,9 +85,6 @@ class SchNetWrap(SchNet):
         if self.regress_forces:
             pos = pos.requires_grad_(True)
         batch = data.batch
-        assert (
-            hasattr(data, "edge_index") or self.otf_graph
-        ), "LMDB does not contain edge indices, set self.otf_graph=True"
 
         if self.otf_graph:
             edge_index, cell_offsets, neighbors = radius_graph_pbc(

--- a/ocpmodels/trainers/energy_trainer.py
+++ b/ocpmodels/trainers/energy_trainer.py
@@ -134,7 +134,9 @@ class EnergyTrainer(BaseTrainer):
     def load_task(self):
         print("### Loading dataset: {}".format(self.config["task"]["dataset"]))
 
-        self.parallel_collater = ParallelCollater(1)
+        self.parallel_collater = ParallelCollater(
+            1, self.config["model_attributes"].get(["otf_graph"], False)
+        )
         if self.config["task"]["dataset"] == "single_point_lmdb":
             self.train_dataset = registry.get_dataset_class(
                 self.config["task"]["dataset"]

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -140,7 +140,9 @@ class ForcesTrainer(BaseTrainer):
     def load_task(self):
         print("### Loading dataset: {}".format(self.config["task"]["dataset"]))
 
-        self.parallel_collater = ParallelCollater(1)
+        self.parallel_collater = ParallelCollater(
+            1, self.config["model_attributes"].get("otf_graph", False)
+        )
         if self.config["task"]["dataset"] == "trajectory_lmdb":
             self.train_dataset = registry.get_dataset_class(
                 self.config["task"]["dataset"]


### PR DESCRIPTION
Resolves codebase errors when trying to train with an LMDB without edge information. Let's merge this into #91 before `release`