### PR TITLE
adds sampler to relaxation loader

### DIFF
--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -205,6 +205,7 @@ class ForcesTrainer(BaseTrainer):
                     collate_fn=self.parallel_collater,
                     num_workers=self.config["optim"]["num_workers"],
                     pin_memory=True,
+                    sampler=self.relax_sampler,
                 )
 
         else:


### PR DESCRIPTION
Relaxation loader uses single-point-lmdb dataset, which requires a distributed sampler. 