### PR TITLE
reverts Path to string

### DIFF
--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -13,12 +13,13 @@ from collections import OrderedDict, defaultdict
 from pathlib import Path
 
 import numpy as np
-import yaml
-from tqdm import tqdm
-
 import torch
 import torch.nn as nn
 import torch.optim as optim
+import yaml
+from torch.nn.parallel.distributed import DistributedDataParallel
+from tqdm import tqdm
+
 from ocpmodels.common import distutils
 from ocpmodels.common.data_parallel import OCPDataParallel
 from ocpmodels.common.logger import TensorboardLogger, WandBLogger
@@ -32,7 +33,6 @@ from ocpmodels.common.utils import (
 )
 from ocpmodels.modules.evaluator import Evaluator
 from ocpmodels.modules.normalizer import Normalizer
-from torch.nn.parallel.distributed import DistributedDataParallel
 
 
 @registry.register_trainer("base")
@@ -58,7 +58,6 @@ class BaseTrainer:
 
         if run_dir is None:
             run_dir = os.getcwd()
-        run_dir = Path(run_dir)
 
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
         if identifier:
@@ -76,9 +75,11 @@ class BaseTrainer:
                 "print_every": print_every,
                 "seed": seed,
                 "timestamp": timestamp,
-                "checkpoint_dir": run_dir / "checkpoints" / timestamp,
-                "results_dir": run_dir / "results" / timestamp,
-                "logs_dir": run_dir / "logs" / logger / timestamp,
+                "checkpoint_dir": os.path.join(
+                    run_dir, "checkpoints", timestamp
+                ),
+                "results_dir": os.path.join(run_dir, "results", timestamp),
+                "logs_dir": os.path.join(run_dir, "logs", logger, timestamp),
             },
         }
         # AMP Scaler

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -58,6 +58,7 @@ class BaseTrainer:
 
         if run_dir is None:
             run_dir = os.getcwd()
+        run_dir = Path(run_dir)
 
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
         if identifier:
@@ -75,11 +76,9 @@ class BaseTrainer:
                 "print_every": print_every,
                 "seed": seed,
                 "timestamp": timestamp,
-                "checkpoint_dir": os.path.join(
-                    run_dir, "checkpoints", timestamp
-                ),
-                "results_dir": os.path.join(run_dir, "results", timestamp),
-                "logs_dir": os.path.join(run_dir, "logs", logger, timestamp),
+                "checkpoint_dir": str(run_dir / "checkpoints" / timestamp),
+                "results_dir": str(run_dir / "results" / timestamp),
+                "logs_dir": str(run_dir / "logs" / logger / timestamp),
             },
         }
         # AMP Scaler


### PR DESCRIPTION
Reverts use of `Path` object to string for easier log parsing. Currently looks like:
```
  checkpoint_dir: !!python/object/apply:pathlib.PosixPath
  - checkpoints
  - 2020-10-26-14-19-34
  identifier: ''
  logs_dir: !!python/object/apply:pathlib.PosixPath
  - logs
  - tensorboard
  - 2020-10-26-14-19-34
  print_every: 10
  results_dir: !!python/object/apply:pathlib.PosixPath
```
Changed to:
```
  checkpoint_dir: ./checkpoints/2020-10-26-14-19-34
  identifier: ''
  logs_dir: ./logs/tensorboard/2020-10-26-14-19-34
  print_every: 10
  results_dir: ./results/2020-10-26-14-19-34
```

We could also call `str()` in front of these lines if we wanted to stick with `Path` https://github.com/Open-Catalyst-Project/ocp/blob/d422307b65bb5e2bd27df60244391570398fa0ae/ocpmodels/trainers/base_trainer.py#L79-L81 Both lead to the same outcome