### PR TITLE
all ranks use master rank timestamps/directories

### DIFF
--- a/ocpmodels/common/distutils.py
+++ b/ocpmodels/common/distutils.py
@@ -95,6 +95,12 @@ def synchronize():
     dist.barrier()
 
 
+def broadcast(tensor, src, group=dist.group.WORLD, async_op=False):
+    if get_world_size() == 1:
+        return
+    dist.broadcast(tensor, src, group, async_op)
+
+
 def all_reduce(data, group=dist.group.WORLD, average=False, device=None):
     if get_world_size() == 1:
         return data

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -65,7 +65,7 @@ class BaseTrainer:
 
         _timestamp = torch.tensor(
             int(datetime.datetime.now().strftime("%Y%m%d%H%M%S"))
-        ).cuda(self.device)
+        ).to(self.device)
 
         # create directories from master rank only
         timestamp = distutils.all_gather(_timestamp)

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -63,17 +63,14 @@ class BaseTrainer:
             run_dir = os.getcwd()
         run_dir = Path(run_dir)
 
-        _timestamp = torch.tensor(
-            int(datetime.datetime.now().strftime("%Y%m%d%H%M%S"))
-        ).to(self.device)
-
+        timestamp = torch.tensor(datetime.datetime.now().timestamp()).to(
+            self.device
+        )
         # create directories from master rank only
-        timestamp = distutils.all_gather(_timestamp)
-        if distutils.get_world_size() > 1:
-            timestamp = timestamp[0]
-        timestamp = datetime.datetime.strptime(
-            str(timestamp.item()), "%Y%m%d%H%M%S"
-        ).strftime("%Y-%m-%d-%H-%M-%S")
+        distutils.broadcast(timestamp, 0)
+        timestamp = datetime.datetime.fromtimestamp(timestamp).strftime(
+            "%Y-%m-%d-%H-%M-%S"
+        )
         if identifier:
             timestamp += "-{}".format(identifier)
 

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -4,7 +4,6 @@ Copyright (c) Facebook, Inc. and its affiliates.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
-
 import datetime
 import json
 import os
@@ -55,12 +54,26 @@ class BaseTrainer:
         name="base_trainer",
     ):
         self.name = name
+        if torch.cuda.is_available():
+            self.device = local_rank
+        else:
+            self.device = "cpu"
 
         if run_dir is None:
             run_dir = os.getcwd()
         run_dir = Path(run_dir)
 
-        timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+        _timestamp = torch.tensor(
+            int(datetime.datetime.now().strftime("%Y%m%d%H%M%S"))
+        ).cuda(self.device)
+
+        # create directories from master rank only
+        timestamp = distutils.all_gather(_timestamp)
+        if distutils.get_world_size() > 1:
+            timestamp = timestamp[0]
+        timestamp = datetime.datetime.strptime(
+            str(timestamp.item()), "%Y%m%d%H%M%S"
+        ).strftime("%Y-%m-%d-%H-%M-%S")
         if identifier:
             timestamp += "-{}".format(identifier)
 
@@ -100,10 +113,6 @@ class BaseTrainer:
 
         self.is_debug = is_debug
         self.is_vis = is_vis
-        if torch.cuda.is_available():
-            self.device = local_rank
-        else:
-            self.device = "cpu"
 
         if distutils.is_master():
             print(yaml.dump(self.config, default_flow_style=False))


### PR DESCRIPTION
Saving predictions in multi-GPU implementations risks hitting an edge case of GPU timestamps being not identical. Resolves this issue by making sure all ranks use the master rank timestamp.