### PR TITLE
Add cpu support for forces trainer

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,6 +42,7 @@ def main(config):
             logger=config.get("logger", "tensorboard"),
             local_rank=config["local_rank"],
             amp=config.get("amp", False),
+            cpu=config.get("cpu", False),
         )
         if config["checkpoint"] is not None:
             trainer.load_pretrained(config["checkpoint"])

--- a/ocpmodels/common/data_parallel.py
+++ b/ocpmodels/common/data_parallel.py
@@ -19,20 +19,33 @@ class OCPDataParallel(torch.nn.DataParallel):
         if num_gpus > torch.cuda.device_count():
             raise ValueError("# GPUs specified larger than available")
 
-        if num_gpus == 1:
+        self.cpu = False
+        if num_gpus == 0:
+            self.cpu = True
+        elif num_gpus == 1:
             device_ids = [output_device]
         else:
             if output_device >= num_gpus:
                 raise ValueError("Main device must be less than # of GPUs")
             device_ids = list(range(num_gpus))
 
-        super(OCPDataParallel, self).__init__(
-            module=module, device_ids=device_ids, output_device=output_device
-        )
+        if self.cpu:
+            super(torch.nn.DataParallel, self).__init__()
+            self.module = module
+
+        else:
+            super(OCPDataParallel, self).__init__(
+                module=module,
+                device_ids=device_ids,
+                output_device=output_device,
+            )
 
         self.src_device = torch.device(output_device)
 
     def forward(self, batch_list):
+        if self.cpu:
+            return self.module(batch_list[0])
+
         if len(self.device_ids) == 1:
             return self.module(batch_list[0].to(f"cuda:{self.device_ids[0]}"))
 
@@ -60,7 +73,7 @@ class ParallelCollater:
         self.otf_graph = otf_graph
 
     def __call__(self, data_list):
-        if self.num_gpus == 1:
+        if self.num_gpus == 0 or self.num_gpus == 1:  # adds cpu-only case
             batch = data_list_collater(data_list, otf_graph=self.otf_graph)
             return [batch]
 

--- a/ocpmodels/common/flags.py
+++ b/ocpmodels/common/flags.py
@@ -112,7 +112,9 @@ class Flags:
         self.parser.add_argument(
             "--distributed", action="store_true", help="Run with DDP"
         )
-
+        self.parser.add_argument(
+            "--cpu", action="store_true", help="Run CPU only training"
+        )
         self.parser.add_argument(
             "--num-nodes",
             default=1,

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -265,6 +265,7 @@ def build_config(args):
     config["print_every"] = args.print_every
     config["amp"] = args.amp
     config["checkpoint"] = args.checkpoint
+    config["cpu"] = args.cpu
     # Submit
     config["submit"] = args.submit
     # Distributed

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -75,6 +75,7 @@ class ForcesTrainer(BaseTrainer):
         logger="tensorboard",
         local_rank=0,
         amp=False,
+        cpu=False,
     ):
         super().__init__(
             task=task,
@@ -90,6 +91,7 @@ class ForcesTrainer(BaseTrainer):
             logger=logger,
             local_rank=local_rank,
             amp=amp,
+            cpu=cpu,
             name="s2ef",
         )
 
@@ -97,7 +99,8 @@ class ForcesTrainer(BaseTrainer):
         print("### Loading dataset: {}".format(self.config["task"]["dataset"]))
 
         self.parallel_collater = ParallelCollater(
-            1, self.config["model_attributes"].get("otf_graph", False)
+            1 if not self.cpu else 0,
+            self.config["model_attributes"].get("otf_graph", False),
         )
         if self.config["task"]["dataset"] == "trajectory_lmdb":
             self.train_dataset = registry.get_dataset_class(


### PR DESCRIPTION
This PR adds the user to train a model on CPU either by:
- specifying a `--cpu` flag from the command line
- on a node without any gpus