### PR TITLE
updates PyG installation binaries

### DIFF
--- a/env.cpu.yml
+++ b/env.cpu.yml
@@ -1,7 +1,8 @@
 dependencies:
   - cpuonly
   - pip:
-    - torch-cluster==1.5.*
-    - torch-scatter==2.0.*
-    - torch-sparse==0.6.*
-    - torch-spline-conv==1.2.*
+    - -f https://pytorch-geometric.com/whl/torch-1.6.0+cpu.html
+    - torch-cluster
+    - torch-scatter
+    - torch-sparse
+    - torch-spline-conv

--- a/env.gpu.yml
+++ b/env.gpu.yml
@@ -5,8 +5,8 @@ channels:
 dependencies:
   - cudatoolkit=10.1
   - pip:
-    - -f https://pytorch-geometric.com/whl/torch-1.6.0.html
-    - torch-cluster==latest+cu101
-    - torch-scatter==latest+cu101
-    - torch-sparse==latest+cu101
-    - torch-spline-conv==latest+cu101
+    - -f https://pytorch-geometric.com/whl/torch-1.6.0+cu101.html
+    - torch-cluster
+    - torch-scatter
+    - torch-sparse
+    - torch-spline-conv


### PR DESCRIPTION
Pytorch Geometric has moved around their installation binaries, breaking our existing installation files. Updates accordingly.

Our build tests weren't catching this because it had the environment cached.