### PR TITLE
Fix run_dir handling

### DIFF
--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -65,7 +65,6 @@ class BaseTrainer:
             # but there are no gpu devices available
         if run_dir is None:
             run_dir = os.getcwd()
-        run_dir = Path(run_dir)
 
         timestamp = torch.tensor(datetime.datetime.now().timestamp()).to(
             self.device
@@ -90,9 +89,9 @@ class BaseTrainer:
                 "print_every": print_every,
                 "seed": seed,
                 "timestamp": timestamp,
-                "checkpoint_dir": str(run_dir / "checkpoints" / timestamp),
-                "results_dir": str(run_dir / "results" / timestamp),
-                "logs_dir": str(run_dir / "logs" / logger / timestamp),
+                "checkpoint_dir": os.path.join(run_dir, "checkpoints", timestamp),
+                "results_dir": os.path.join(run_dir, "results", timestamp),
+                "logs_dir": os.path.join(run_dir, "logs", logger, timestamp),
             },
         }
         # AMP Scaler


### PR DESCRIPTION
This fix allows the use of alternative TensorBoard SummaryWriter's (e.g., GFile, S3, etc). Using `pathlib.Path`, it changes incoming `--run-dir=s3://path` to `s3:/path` (Note the single slash) and the `SummaryWriter` check fails to match due to the single slash.

The fix is to not wrap in a `pathlib.Path` and do inline concatenation using os.path.join

_(Note too that to use tensorboard logging to s3 you have to include `boto3` as a dependency)_

- [0] https://github.com/tensorflow/tensorboard/blob/master/tensorboard/compat/tensorflow_stub/io/gfile.py#L224
- [1] https://github.com/tensorflow/tensorboard/blob/master/tensorboard/compat/tensorflow_stub/io/gfile.py#L38