### PR TITLE
update config override

### DIFF
--- a/main.py
+++ b/main.py
@@ -86,8 +86,8 @@ def main(config):
 
 if __name__ == "__main__":
     parser = flags.get_parser()
-    args = parser.parse_args()
-    config = build_config(args)
+    args, override_args = parser.parse_known_args()
+    config = build_config(args, override_args)
 
     if args.submit:  # Run on cluster
         if args.sweep_yml:  # Run grid search

--- a/ocpmodels/common/flags.py
+++ b/ocpmodels/common/flags.py
@@ -34,11 +34,6 @@ class Flags:
             help="Path to a config file listing data, model, optim parameters.",
         )
         self.parser.add_argument(
-            "--config-override",
-            default=None,
-            help="Optional override for parameters defined in config yaml",
-        )
-        self.parser.add_argument(
             "--identifier",
             default="",
             type=str,

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -30,20 +30,6 @@ def save_checkpoint(state, checkpoint_dir="checkpoints/"):
     torch.save(state, filename)
 
 
-# https://stackoverflow.com/questions/38987/how-to-merge-two-dictionaries-in-a-single-expression
-def update_config(original, update):
-    """
-    Recursively update a dict.
-    Subdict's won't be overwritten but also updated.
-    """
-    for key, value in original.items():
-        if key not in update:
-            update[key] = value
-        elif isinstance(value, dict):
-            update_config(value, update[key])
-    return update
-
-
 class Complete(object):
     def __call__(self, data):
         device = data.edge_index.device
@@ -234,7 +220,43 @@ def setup_imports():
     registry.register("imports_setup", True)
 
 
-def build_config(args):
+def create_config_dict(args):
+    overrides = {}
+    for arg in args:
+        arg = arg.strip("--")
+        key, val = arg.split("=")
+        overrides[key] = val
+    return overrides
+
+
+# https://stackoverflow.com/questions/38987/how-to-merge-two-dictionaries-in-a-single-expression
+def update_config(original, update):
+    """
+    Recursively update a dict.
+    Subdict's won't be overwritten but also updated.
+    """
+    for key, value in original.items():
+        if key not in update:
+            update[key] = value
+        elif isinstance(value, dict):
+            update_config(value, update[key])
+    return update
+
+
+def cmd_update_config(original, update):
+    """
+    Recursively update a dict.
+    Parameters must be specified in original to be overwritten
+    """
+    for basekey, baseval in original.items():
+        if isinstance(baseval, dict):
+            for key, val in baseval.items():
+                if key in update:
+                    original[basekey][key] = demjson.decode(update[key])
+    return original
+
+
+def build_config(args, args_override):
     config = yaml.safe_load(open(args.config_yml, "r"))
 
     # Load config from included files.
@@ -252,6 +274,11 @@ def build_config(args):
         config.pop("includes")
 
     # Check for overriden parameters.
+    if args_override != []:
+        overrides = create_config_dict(args_override)
+        config = cmd_update_config(config, overrides)
+
+    # Check for overriden parameters (DEPRECATED).
     if args.config_override:
         overrides = demjson.decode(args.config_override)
         config = update_config(config, overrides)

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -229,21 +229,7 @@ def create_config_dict(args):
     return overrides
 
 
-# https://stackoverflow.com/questions/38987/how-to-merge-two-dictionaries-in-a-single-expression
 def update_config(original, update):
-    """
-    Recursively update a dict.
-    Subdict's won't be overwritten but also updated.
-    """
-    for key, value in original.items():
-        if key not in update:
-            update[key] = value
-        elif isinstance(value, dict):
-            update_config(value, update[key])
-    return update
-
-
-def cmd_update_config(original, update):
     """
     Recursively update a dict.
     Parameters must be specified in original to be overwritten
@@ -276,11 +262,6 @@ def build_config(args, args_override):
     # Check for overriden parameters.
     if args_override != []:
         overrides = create_config_dict(args_override)
-        config = cmd_update_config(config, overrides)
-
-    # Check for overriden parameters (DEPRECATED).
-    if args.config_override:
-        overrides = demjson.decode(args.config_override)
         config = update_config(config, overrides)
 
     # Some other flags.


### PR DESCRIPTION
Overriding configs from command line is currently structured as:
`python main.py ... ... --config-override '{"model":{"num_layers": 3, "hidden_channels":128, ...}}'`

This structure, however, makes integrating with HPO tools a challenge as they often feed in arguments as:
`python main.py ... ... --num_layers=3 --hidden_channels=128 ...`

This PR allows model hyperparameters to be overridden directly in the above format. `config-override` is left as part of this PR unless we think we can safely remove. One notable difference is `config-override` allows you to specify new arguments not already contained in the yaml configs, while the changes here can only modify existing parameters defined in the yaml configs.

As an example, this PR specifically allows the use of wandb's HPO: https://docs.wandb.com/sweeps via:

`sweep.yml`
```
program: main.py
method: bayes
command:
  - ${env}
  - ${interpreter}
  - ${program}
  - "--config-yml"
  - configs/is2re/10k/cgcnn/cgcnn.yml
  - "--mode"
  - train
  - ${args}
parameters:
  learning_rate:
    min: 0.001
    max: 0.1
```
```
wandb sweep sweep.yml
wandb agent $AGENT_ID (output from the above command)
```

Note - none of the changes in this PR are specific to wandb, but rather used as an example.