### PR TITLE
Forcenet config fix

### DIFF
--- a/configs/s2ef/all/forcenet/fn_forceonly.yml
+++ b/configs/s2ef/all/forcenet/fn_forceonly.yml
@@ -1,7 +1,7 @@
 trainer: forces
 
 dataset:
-  - src: data/s2ef/200k/train/
+  - src: data/s2ef/all/train/
   - src: data/s2ef/all/val_id/
 
 model:


### PR DESCRIPTION
Addresses issue #167: Forcenet config stored in `configs/s2ef/all` but reads 200k set instead of all. Updates accordingly.

