### PR TITLE
Log git commit and no. of gpus used for better debugging

### DIFF
--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -8,6 +8,7 @@ import datetime
 import json
 import os
 import random
+import subprocess
 from collections import OrderedDict, defaultdict
 from pathlib import Path
 
@@ -84,11 +85,17 @@ class BaseTrainer:
             "optim": optimizer,
             "logger": logger,
             "amp": amp,
+            "gpus": distutils.get_world_size() if not self.cpu else 0,
             "cmd": {
                 "identifier": identifier,
                 "print_every": print_every,
                 "seed": seed,
                 "timestamp": timestamp,
+                "commit": subprocess.check_output(
+                    ["git", "describe", "--always"]
+                )
+                .strip()
+                .decode("ascii"),
                 "checkpoint_dir": os.path.join(
                     run_dir, "checkpoints", timestamp
                 ),


### PR DESCRIPTION
Logs commit # and no. of gpus used for training (this isn't easily identified by looking at a config)

Sample output - note `commit` and `gpus`
```
### Loading dataset: trajectory_lmdb
amp: false
cmd:
  checkpoint_dir: ./checkpoints/2021-01-06-22-56-00
  commit: 4b00139
  identifier: ''
  logs_dir: ./logs/tensorboard/2021-01-06-22-56-00
  print_every: 10
  results_dir: ./results/2021-01-06-22-56-00
  seed: 0
  timestamp: 2021-01-06-22-56-00
dataset:
  grad_target_mean: 0.0
  grad_target_std: 2.887317180633545
  normalize_labels: true
  src: data/s2ef/200k/train/
  target_mean: -0.7554450631141663
  target_std: 2.887317180633545
gpus: 2
logger: tensorboard
model: schnet
model_attributes:
  cutoff: 6.0
  hidden_channels: 1024
  num_filters: 256
  num_gaussians: 200
  num_interactions: 3
  use_pbc: true
optim:
  batch_size: 32
  eval_batch_size: 16
  force_coefficient: 100
  lr_gamma: 0.1
  lr_initial: 0.0005
  lr_milestones:
  - 5
  - 8
  - 10
  max_epochs: 30
  num_workers: 64
  warmup_epochs: 3
  warmup_factor: 0.2
task:
  dataset: trajectory_lmdb
  description: Regressing to energies and forces for DFT trajectories from OCP
  eval_on_free_atoms: true
  grad_input: atomic forces
  labels:
  - potential energy
  metric: mae
  train_on_free_atoms: true
  type: regression
val_dataset:
  src: data/s2ef/all/val_id/

### Loading dataset: trajectory_lmdb
### Loading model: schnet
### Loaded SchNet with 5704193 parameters.
```

Logging `commit` will need to be changed if we decide to make the repo pip installable in the future.