### PR TITLE
catch for no fixed atoms

### DIFF
--- a/ocpmodels/preprocessing/atoms_to_graphs.py
+++ b/ocpmodels/preprocessing/atoms_to_graphs.py
@@ -162,7 +162,12 @@ class AtomsToGraphs:
             data.distances = edge_distances
         if self.r_fixed:
             fixed_idx = torch.zeros(natoms)
-            fixed_idx[atoms.constraints[0].index] = 1
+            if hasattr(atoms, "constraints"):
+                from ase.constraints import FixAtoms
+
+                for constraint in atoms.constraints:
+                    if isinstance(constraint, FixAtoms):
+                        fixed_idx[atoms.constraints[0].index] = 1
             data.fixed = fixed_idx
 
         return data

--- a/ocpmodels/preprocessing/atoms_to_graphs.py
+++ b/ocpmodels/preprocessing/atoms_to_graphs.py
@@ -167,7 +167,7 @@ class AtomsToGraphs:
 
                 for constraint in atoms.constraints:
                     if isinstance(constraint, FixAtoms):
-                        fixed_idx[atoms.constraints[0].index] = 1
+                        fixed_idx[constraint.index] = 1
             data.fixed = fixed_idx
 
         return data


### PR DESCRIPTION
Users generating LMDBs with data that does not have fixed atoms defined are unable to with existing preprocessing script. Resolves that issue.