### PR TITLE
Resolves validation gpu memory issue

### DIFF
--- a/ocpmodels/models/cgcnn.py
+++ b/ocpmodels/models/cgcnn.py
@@ -101,56 +101,61 @@ class CGCNN(BaseModel):
         self.cutoff = cutoff
         self.distance_expansion = GaussianSmearing(0.0, cutoff, num_gaussians)
 
+    @torch.enable_grad()
+    def _forward(self, data):
+        # Get node features
+        if self.embedding.device != data.atomic_numbers.device:
+            self.embedding = self.embedding.to(data.atomic_numbers.device)
+        data.x = self.embedding[data.atomic_numbers.long() - 1]
+
+        pos = data.pos
+
+        if self.otf_graph:
+            edge_index, cell_offsets, neighbors = radius_graph_pbc(
+                data, self.cutoff, 50, data.pos.device
+            )
+            data.edge_index = edge_index
+            data.cell_offsets = cell_offsets
+            data.neighbors = neighbors
+
+        if self.use_pbc:
+            out = get_pbc_distances(
+                pos,
+                data.edge_index,
+                data.cell,
+                data.cell_offsets,
+                data.neighbors,
+            )
+
+            data.edge_index = out["edge_index"]
+            distances = out["distances"]
+        else:
+            data.edge_index = radius_graph(
+                data.pos, r=self.cutoff, batch=data.batch
+            )
+            row, col = data.edge_index
+            distances = (pos[row] - pos[col]).norm(dim=-1)
+
+        data.edge_attr = self.distance_expansion(distances)
+        # Forward pass through the network
+        mol_feats = self._convolve(data)
+        mol_feats = self.conv_to_fc(mol_feats)
+        if hasattr(self, "fcs"):
+            mol_feats = self.fcs(mol_feats)
+
+        energy = self.fc_out(mol_feats)
+        return energy
+
     def forward(self, data):
-        with torch.enable_grad():
-            # Get node features
-            if self.embedding.device != data.atomic_numbers.device:
-                self.embedding = self.embedding.to(data.atomic_numbers.device)
-            data.x = self.embedding[data.atomic_numbers.long() - 1]
+        if self.regress_forces:
+            data.pos.requires_grad_(True)
+        energy = self._forward(data)
 
-            pos = data.pos
-            if self.regress_forces:
-                pos = pos.requires_grad_(True)
-
-            if self.otf_graph:
-                edge_index, cell_offsets, neighbors = radius_graph_pbc(
-                    data, self.cutoff, 50, data.pos.device
-                )
-                data.edge_index = edge_index
-                data.cell_offsets = cell_offsets
-                data.neighbors = neighbors
-
-            if self.use_pbc:
-                out = get_pbc_distances(
-                    pos,
-                    data.edge_index,
-                    data.cell,
-                    data.cell_offsets,
-                    data.neighbors,
-                )
-
-                data.edge_index = out["edge_index"]
-                distances = out["distances"]
-            else:
-                data.edge_index = radius_graph(
-                    data.pos, r=self.cutoff, batch=data.batch
-                )
-                row, col = data.edge_index
-                distances = (pos[row] - pos[col]).norm(dim=-1)
-
-            data.edge_attr = self.distance_expansion(distances)
-            # Forward pass through the network
-            mol_feats = self._convolve(data)
-            mol_feats = self.conv_to_fc(mol_feats)
-            if hasattr(self, "fcs"):
-                mol_feats = self.fcs(mol_feats)
-
-            energy = self.fc_out(mol_feats)
         if self.regress_forces:
             forces = -1 * (
                 torch.autograd.grad(
                     energy,
-                    pos,
+                    data.pos,
                     grad_outputs=torch.ones_like(energy),
                     create_graph=True,
                 )[0]

--- a/ocpmodels/models/dimenet.py
+++ b/ocpmodels/models/dimenet.py
@@ -101,84 +101,91 @@ class DimeNetWrap(DimeNet):
         )
 
     def forward(self, data):
-        pos = data.pos
-        if self.regress_forces:
-            pos = pos.requires_grad_(True)
-        batch = data.batch
+        with torch.enable_grad():
+            pos = data.pos
+            if self.regress_forces:
+                pos = pos.requires_grad_(True)
+            batch = data.batch
 
-        if self.otf_graph:
-            edge_index, cell_offsets, neighbors = radius_graph_pbc(
-                data, self.cutoff, 50, data.pos.device
-            )
-            data.edge_index = edge_index
-            data.cell_offsets = cell_offsets
-            data.neighbors = neighbors
+            if self.otf_graph:
+                edge_index, cell_offsets, neighbors = radius_graph_pbc(
+                    data, self.cutoff, 50, data.pos.device
+                )
+                data.edge_index = edge_index
+                data.cell_offsets = cell_offsets
+                data.neighbors = neighbors
 
-        if self.use_pbc:
-            out = get_pbc_distances(
-                pos,
-                data.edge_index,
-                data.cell,
-                data.cell_offsets,
-                data.neighbors,
-                return_offsets=True,
-            )
+            if self.use_pbc:
+                out = get_pbc_distances(
+                    pos,
+                    data.edge_index,
+                    data.cell,
+                    data.cell_offsets,
+                    data.neighbors,
+                    return_offsets=True,
+                )
 
-            edge_index = out["edge_index"]
-            dist = out["distances"]
-            offsets = out["offsets"]
+                edge_index = out["edge_index"]
+                dist = out["distances"]
+                offsets = out["offsets"]
 
-            j, i = edge_index
-        else:
-            edge_index = radius_graph(pos, r=self.cutoff, batch=batch)
-            j, i = edge_index
-            dist = (pos[i] - pos[j]).pow(2).sum(dim=-1).sqrt()
+                j, i = edge_index
+            else:
+                edge_index = radius_graph(pos, r=self.cutoff, batch=batch)
+                j, i = edge_index
+                dist = (pos[i] - pos[j]).pow(2).sum(dim=-1).sqrt()
 
-        _, _, idx_i, idx_j, idx_k, idx_kj, idx_ji = self.triplets(
-            edge_index, num_nodes=data.atomic_numbers.size(0)
-        )
-
-        # Cap no. of triplets during training.
-        if self.training:
-            sub_ix = torch.randperm(idx_i.size(0))[
-                : self.max_angles_per_image * data.natoms.size(0)
-            ]
-            idx_i, idx_j, idx_k = idx_i[sub_ix], idx_j[sub_ix], idx_k[sub_ix]
-            idx_kj, idx_ji = idx_kj[sub_ix], idx_ji[sub_ix]
-
-        # Calculate angles.
-        pos_i = pos[idx_i].detach()
-        pos_j = pos[idx_j].detach()
-        if self.use_pbc:
-            pos_ji, pos_kj = (
-                pos[idx_j].detach() - pos_i + offsets[idx_ji],
-                pos[idx_k].detach() - pos_j + offsets[idx_kj],
-            )
-        else:
-            pos_ji, pos_kj = (
-                pos[idx_j].detach() - pos_i,
-                pos[idx_k].detach() - pos_j,
+            _, _, idx_i, idx_j, idx_k, idx_kj, idx_ji = self.triplets(
+                edge_index, num_nodes=data.atomic_numbers.size(0)
             )
 
-        a = (pos_ji * pos_kj).sum(dim=-1)
-        b = torch.cross(pos_ji, pos_kj).norm(dim=-1)
-        angle = torch.atan2(b, a)
+            # Cap no. of triplets during training.
+            if self.training:
+                sub_ix = torch.randperm(idx_i.size(0))[
+                    : self.max_angles_per_image * data.natoms.size(0)
+                ]
+                idx_i, idx_j, idx_k = (
+                    idx_i[sub_ix],
+                    idx_j[sub_ix],
+                    idx_k[sub_ix],
+                )
+                idx_kj, idx_ji = idx_kj[sub_ix], idx_ji[sub_ix]
 
-        rbf = self.rbf(dist)
-        sbf = self.sbf(dist, angle, idx_kj)
+            # Calculate angles.
+            pos_i = pos[idx_i].detach()
+            pos_j = pos[idx_j].detach()
+            if self.use_pbc:
+                pos_ji, pos_kj = (
+                    pos[idx_j].detach() - pos_i + offsets[idx_ji],
+                    pos[idx_k].detach() - pos_j + offsets[idx_kj],
+                )
+            else:
+                pos_ji, pos_kj = (
+                    pos[idx_j].detach() - pos_i,
+                    pos[idx_k].detach() - pos_j,
+                )
 
-        # Embedding block.
-        x = self.emb(data.atomic_numbers.long(), rbf, i, j)
-        P = self.output_blocks[0](x, rbf, i, num_nodes=pos.size(0))
+            a = (pos_ji * pos_kj).sum(dim=-1)
+            b = torch.cross(pos_ji, pos_kj).norm(dim=-1)
+            angle = torch.atan2(b, a)
 
-        # Interaction blocks.
-        for interaction_block, output_block in zip(
-            self.interaction_blocks, self.output_blocks[1:]
-        ):
-            x = interaction_block(x, rbf, sbf, idx_kj, idx_ji)
-            P += output_block(x, rbf, i, num_nodes=pos.size(0))
+            rbf = self.rbf(dist)
+            sbf = self.sbf(dist, angle, idx_kj)
 
-        energy = P.sum(dim=0) if batch is None else scatter(P, batch, dim=0)
+            # Embedding block.
+            x = self.emb(data.atomic_numbers.long(), rbf, i, j)
+            P = self.output_blocks[0](x, rbf, i, num_nodes=pos.size(0))
+
+            # Interaction blocks.
+            for interaction_block, output_block in zip(
+                self.interaction_blocks, self.output_blocks[1:]
+            ):
+                x = interaction_block(x, rbf, sbf, idx_kj, idx_ji)
+                P += output_block(x, rbf, i, num_nodes=pos.size(0))
+
+            energy = (
+                P.sum(dim=0) if batch is None else scatter(P, batch, dim=0)
+            )
 
         if self.regress_forces:
             forces = -1 * (

--- a/ocpmodels/models/dimenet_plus_plus.py
+++ b/ocpmodels/models/dimenet_plus_plus.py
@@ -370,86 +370,89 @@ class DimeNetPlusPlusWrap(DimeNetPlusPlus):
             num_output_layers=num_output_layers,
         )
 
+    @torch.enable_grad()
+    def _forward(self, data):
+        pos = data.pos
+        batch = data.batch
+
+        if self.otf_graph:
+            edge_index, cell_offsets, neighbors = radius_graph_pbc(
+                data, self.cutoff, 50, data.pos.device
+            )
+            data.edge_index = edge_index
+            data.cell_offsets = cell_offsets
+            data.neighbors = neighbors
+
+        if self.use_pbc:
+            out = get_pbc_distances(
+                pos,
+                data.edge_index,
+                data.cell,
+                data.cell_offsets,
+                data.neighbors,
+                return_offsets=True,
+            )
+
+            edge_index = out["edge_index"]
+            dist = out["distances"]
+            offsets = out["offsets"]
+
+            j, i = edge_index
+        else:
+            edge_index = radius_graph(pos, r=self.cutoff, batch=batch)
+            j, i = edge_index
+            dist = (pos[i] - pos[j]).pow(2).sum(dim=-1).sqrt()
+
+        _, _, idx_i, idx_j, idx_k, idx_kj, idx_ji = self.triplets(
+            edge_index, num_nodes=data.atomic_numbers.size(0)
+        )
+
+        # Calculate angles.
+        pos_i = pos[idx_i].detach()
+        pos_j = pos[idx_j].detach()
+        if self.use_pbc:
+            pos_ji, pos_kj = (
+                pos[idx_j].detach() - pos_i + offsets[idx_ji],
+                pos[idx_k].detach() - pos_j + offsets[idx_kj],
+            )
+        else:
+            pos_ji, pos_kj = (
+                pos[idx_j].detach() - pos_i,
+                pos[idx_k].detach() - pos_j,
+            )
+
+        a = (pos_ji * pos_kj).sum(dim=-1)
+        b = torch.cross(pos_ji, pos_kj).norm(dim=-1)
+        angle = torch.atan2(b, a)
+
+        rbf = self.rbf(dist)
+        sbf = self.sbf(dist, angle, idx_kj)
+
+        # Embedding block.
+        x = self.emb(data.atomic_numbers.long(), rbf, i, j)
+        P = self.output_blocks[0](x, rbf, i, num_nodes=pos.size(0))
+
+        # Interaction blocks.
+        for interaction_block, output_block in zip(
+            self.interaction_blocks, self.output_blocks[1:]
+        ):
+            x = interaction_block(x, rbf, sbf, idx_kj, idx_ji)
+            P += output_block(x, rbf, i, num_nodes=pos.size(0))
+
+        energy = P.sum(dim=0) if batch is None else scatter(P, batch, dim=0)
+
+        return energy
+
     def forward(self, data):
-        with torch.enable_grad():
-            pos = data.pos
-            if self.regress_forces:
-                pos = pos.requires_grad_(True)
-            batch = data.batch
-
-            if self.otf_graph:
-                edge_index, cell_offsets, neighbors = radius_graph_pbc(
-                    data, self.cutoff, 50, data.pos.device
-                )
-                data.edge_index = edge_index
-                data.cell_offsets = cell_offsets
-                data.neighbors = neighbors
-
-            if self.use_pbc:
-                out = get_pbc_distances(
-                    pos,
-                    data.edge_index,
-                    data.cell,
-                    data.cell_offsets,
-                    data.neighbors,
-                    return_offsets=True,
-                )
-
-                edge_index = out["edge_index"]
-                dist = out["distances"]
-                offsets = out["offsets"]
-
-                j, i = edge_index
-            else:
-                edge_index = radius_graph(pos, r=self.cutoff, batch=batch)
-                j, i = edge_index
-                dist = (pos[i] - pos[j]).pow(2).sum(dim=-1).sqrt()
-
-            _, _, idx_i, idx_j, idx_k, idx_kj, idx_ji = self.triplets(
-                edge_index, num_nodes=data.atomic_numbers.size(0)
-            )
-
-            # Calculate angles.
-            pos_i = pos[idx_i].detach()
-            pos_j = pos[idx_j].detach()
-            if self.use_pbc:
-                pos_ji, pos_kj = (
-                    pos[idx_j].detach() - pos_i + offsets[idx_ji],
-                    pos[idx_k].detach() - pos_j + offsets[idx_kj],
-                )
-            else:
-                pos_ji, pos_kj = (
-                    pos[idx_j].detach() - pos_i,
-                    pos[idx_k].detach() - pos_j,
-                )
-
-            a = (pos_ji * pos_kj).sum(dim=-1)
-            b = torch.cross(pos_ji, pos_kj).norm(dim=-1)
-            angle = torch.atan2(b, a)
-
-            rbf = self.rbf(dist)
-            sbf = self.sbf(dist, angle, idx_kj)
-
-            # Embedding block.
-            x = self.emb(data.atomic_numbers.long(), rbf, i, j)
-            P = self.output_blocks[0](x, rbf, i, num_nodes=pos.size(0))
-
-            # Interaction blocks.
-            for interaction_block, output_block in zip(
-                self.interaction_blocks, self.output_blocks[1:]
-            ):
-                x = interaction_block(x, rbf, sbf, idx_kj, idx_ji)
-                P += output_block(x, rbf, i, num_nodes=pos.size(0))
-
-            energy = (
-                P.sum(dim=0) if batch is None else scatter(P, batch, dim=0)
-            )
+        if self.regress_forces:
+            data.pos.requires_grad_(True)
+        energy = self._forward(data)
 
         if self.regress_forces:
             forces = -1 * (
                 torch.autograd.grad(
                     energy,
-                    pos,
+                    data.pos,
                     grad_outputs=torch.ones_like(energy),
                     create_graph=True,
                 )[0]

--- a/ocpmodels/models/dimenet_plus_plus.py
+++ b/ocpmodels/models/dimenet_plus_plus.py
@@ -371,76 +371,79 @@ class DimeNetPlusPlusWrap(DimeNetPlusPlus):
         )
 
     def forward(self, data):
-        pos = data.pos
-        if self.regress_forces:
-            pos = pos.requires_grad_(True)
-        batch = data.batch
+        with torch.enable_grad():
+            pos = data.pos
+            if self.regress_forces:
+                pos = pos.requires_grad_(True)
+            batch = data.batch
 
-        if self.otf_graph:
-            edge_index, cell_offsets, neighbors = radius_graph_pbc(
-                data, self.cutoff, 50, data.pos.device
-            )
-            data.edge_index = edge_index
-            data.cell_offsets = cell_offsets
-            data.neighbors = neighbors
+            if self.otf_graph:
+                edge_index, cell_offsets, neighbors = radius_graph_pbc(
+                    data, self.cutoff, 50, data.pos.device
+                )
+                data.edge_index = edge_index
+                data.cell_offsets = cell_offsets
+                data.neighbors = neighbors
 
-        if self.use_pbc:
-            out = get_pbc_distances(
-                pos,
-                data.edge_index,
-                data.cell,
-                data.cell_offsets,
-                data.neighbors,
-                return_offsets=True,
-            )
+            if self.use_pbc:
+                out = get_pbc_distances(
+                    pos,
+                    data.edge_index,
+                    data.cell,
+                    data.cell_offsets,
+                    data.neighbors,
+                    return_offsets=True,
+                )
 
-            edge_index = out["edge_index"]
-            dist = out["distances"]
-            offsets = out["offsets"]
+                edge_index = out["edge_index"]
+                dist = out["distances"]
+                offsets = out["offsets"]
 
-            j, i = edge_index
-        else:
-            edge_index = radius_graph(pos, r=self.cutoff, batch=batch)
-            j, i = edge_index
-            dist = (pos[i] - pos[j]).pow(2).sum(dim=-1).sqrt()
+                j, i = edge_index
+            else:
+                edge_index = radius_graph(pos, r=self.cutoff, batch=batch)
+                j, i = edge_index
+                dist = (pos[i] - pos[j]).pow(2).sum(dim=-1).sqrt()
 
-        _, _, idx_i, idx_j, idx_k, idx_kj, idx_ji = self.triplets(
-            edge_index, num_nodes=data.atomic_numbers.size(0)
-        )
-
-        # Calculate angles.
-        pos_i = pos[idx_i].detach()
-        pos_j = pos[idx_j].detach()
-        if self.use_pbc:
-            pos_ji, pos_kj = (
-                pos[idx_j].detach() - pos_i + offsets[idx_ji],
-                pos[idx_k].detach() - pos_j + offsets[idx_kj],
-            )
-        else:
-            pos_ji, pos_kj = (
-                pos[idx_j].detach() - pos_i,
-                pos[idx_k].detach() - pos_j,
+            _, _, idx_i, idx_j, idx_k, idx_kj, idx_ji = self.triplets(
+                edge_index, num_nodes=data.atomic_numbers.size(0)
             )
 
-        a = (pos_ji * pos_kj).sum(dim=-1)
-        b = torch.cross(pos_ji, pos_kj).norm(dim=-1)
-        angle = torch.atan2(b, a)
+            # Calculate angles.
+            pos_i = pos[idx_i].detach()
+            pos_j = pos[idx_j].detach()
+            if self.use_pbc:
+                pos_ji, pos_kj = (
+                    pos[idx_j].detach() - pos_i + offsets[idx_ji],
+                    pos[idx_k].detach() - pos_j + offsets[idx_kj],
+                )
+            else:
+                pos_ji, pos_kj = (
+                    pos[idx_j].detach() - pos_i,
+                    pos[idx_k].detach() - pos_j,
+                )
 
-        rbf = self.rbf(dist)
-        sbf = self.sbf(dist, angle, idx_kj)
+            a = (pos_ji * pos_kj).sum(dim=-1)
+            b = torch.cross(pos_ji, pos_kj).norm(dim=-1)
+            angle = torch.atan2(b, a)
 
-        # Embedding block.
-        x = self.emb(data.atomic_numbers.long(), rbf, i, j)
-        P = self.output_blocks[0](x, rbf, i, num_nodes=pos.size(0))
+            rbf = self.rbf(dist)
+            sbf = self.sbf(dist, angle, idx_kj)
 
-        # Interaction blocks.
-        for interaction_block, output_block in zip(
-            self.interaction_blocks, self.output_blocks[1:]
-        ):
-            x = interaction_block(x, rbf, sbf, idx_kj, idx_ji)
-            P += output_block(x, rbf, i, num_nodes=pos.size(0))
+            # Embedding block.
+            x = self.emb(data.atomic_numbers.long(), rbf, i, j)
+            P = self.output_blocks[0](x, rbf, i, num_nodes=pos.size(0))
 
-        energy = P.sum(dim=0) if batch is None else scatter(P, batch, dim=0)
+            # Interaction blocks.
+            for interaction_block, output_block in zip(
+                self.interaction_blocks, self.output_blocks[1:]
+            ):
+                x = interaction_block(x, rbf, sbf, idx_kj, idx_ji)
+                P += output_block(x, rbf, i, num_nodes=pos.size(0))
+
+            energy = (
+                P.sum(dim=0) if batch is None else scatter(P, batch, dim=0)
+            )
 
         if self.regress_forces:
             forces = -1 * (

--- a/ocpmodels/models/schnet.py
+++ b/ocpmodels/models/schnet.py
@@ -79,57 +79,61 @@ class SchNetWrap(SchNet):
             readout=readout,
         )
 
+    @torch.enable_grad()
+    def _forward(self, data):
+        z = data.atomic_numbers.long()
+        pos = data.pos
+        batch = data.batch
+
+        if self.otf_graph:
+            edge_index, cell_offsets, neighbors = radius_graph_pbc(
+                data, self.cutoff, 50, data.pos.device
+            )
+            data.edge_index = edge_index
+            data.cell_offsets = cell_offsets
+            data.neighbors = neighbors
+
+        # TODO return distance computation in radius_graph_pbc to remove need
+        # for get_pbc_distances call
+        if self.use_pbc:
+            assert z.dim() == 1 and z.dtype == torch.long
+
+            out = get_pbc_distances(
+                pos,
+                data.edge_index,
+                data.cell,
+                data.cell_offsets,
+                data.neighbors,
+            )
+
+            edge_index = out["edge_index"]
+            edge_weight = out["distances"]
+            edge_attr = self.distance_expansion(edge_weight)
+
+            h = self.embedding(z)
+            for interaction in self.interactions:
+                h = h + interaction(h, edge_index, edge_weight, edge_attr)
+
+            h = self.lin1(h)
+            h = self.act(h)
+            h = self.lin2(h)
+
+            batch = torch.zeros_like(z) if batch is None else batch
+            energy = scatter(h, batch, dim=0, reduce=self.readout)
+        else:
+            energy = super(SchNetWrap, self).forward(z, pos, batch)
+        return energy
+
     def forward(self, data):
-        with torch.enable_grad():
-            z = data.atomic_numbers.long()
-            pos = data.pos
-            if self.regress_forces:
-                pos = pos.requires_grad_(True)
-            batch = data.batch
-
-            if self.otf_graph:
-                edge_index, cell_offsets, neighbors = radius_graph_pbc(
-                    data, self.cutoff, 50, data.pos.device
-                )
-                data.edge_index = edge_index
-                data.cell_offsets = cell_offsets
-                data.neighbors = neighbors
-
-            # TODO return distance computation in radius_graph_pbc to remove need
-            # for get_pbc_distances call
-            if self.use_pbc:
-                assert z.dim() == 1 and z.dtype == torch.long
-
-                out = get_pbc_distances(
-                    pos,
-                    data.edge_index,
-                    data.cell,
-                    data.cell_offsets,
-                    data.neighbors,
-                )
-
-                edge_index = out["edge_index"]
-                edge_weight = out["distances"]
-                edge_attr = self.distance_expansion(edge_weight)
-
-                h = self.embedding(z)
-                for interaction in self.interactions:
-                    h = h + interaction(h, edge_index, edge_weight, edge_attr)
-
-                h = self.lin1(h)
-                h = self.act(h)
-                h = self.lin2(h)
-
-                batch = torch.zeros_like(z) if batch is None else batch
-                energy = scatter(h, batch, dim=0, reduce=self.readout)
-            else:
-                energy = super(SchNetWrap, self).forward(z, pos, batch)
+        if self.regress_forces:
+            data.pos.requires_grad_(True)
+        energy = self._forward(data)
 
         if self.regress_forces:
             forces = -1 * (
                 torch.autograd.grad(
                     energy,
-                    pos,
+                    data.pos,
                     grad_outputs=torch.ones_like(energy),
                     create_graph=True,
                 )[0]

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -516,58 +516,63 @@ class BaseTrainer:
             }
 
     def validate(self, split="val", epoch=None):
-        if distutils.is_master():
-            print("### Evaluating on {}.".format(split))
+        with torch.no_grad():
+            if distutils.is_master():
+                print("### Evaluating on {}.".format(split))
 
-        self.model.eval()
-        evaluator, metrics = Evaluator(task=self.name), {}
-        rank = distutils.get_rank()
+            self.model.eval()
+            evaluator, metrics = Evaluator(task=self.name), {}
+            rank = distutils.get_rank()
 
-        loader = self.val_loader if split == "val" else self.test_loader
+            loader = self.val_loader if split == "val" else self.test_loader
 
-        for i, batch in tqdm(
-            enumerate(loader),
-            total=len(loader),
-            position=rank,
-            desc="device {}".format(rank),
-        ):
-            # Forward.
-            with torch.cuda.amp.autocast(enabled=self.scaler is not None):
-                out = self._forward(batch)
-            loss = self._compute_loss(out, batch)
+            for i, batch in tqdm(
+                enumerate(loader),
+                total=len(loader),
+                position=rank,
+                desc="device {}".format(rank),
+                disable=True,
+            ):
+                # Forward.
+                with torch.cuda.amp.autocast(enabled=self.scaler is not None):
+                    out = self._forward(batch)
+                loss = self._compute_loss(out, batch)
 
-            # Compute metrics.
-            metrics = self._compute_metrics(out, batch, evaluator, metrics)
-            metrics = evaluator.update("loss", loss.item(), metrics)
+                # Compute metrics.
+                metrics = self._compute_metrics(out, batch, evaluator, metrics)
+                metrics = evaluator.update("loss", loss.item(), metrics)
 
-        aggregated_metrics = {}
-        for k in metrics:
-            aggregated_metrics[k] = {
-                "total": distutils.all_reduce(
-                    metrics[k]["total"], average=False, device=self.device
-                ),
-                "numel": distutils.all_reduce(
-                    metrics[k]["numel"], average=False, device=self.device
-                ),
-            }
-            aggregated_metrics[k]["metric"] = (
-                aggregated_metrics[k]["total"] / aggregated_metrics[k]["numel"]
-            )
-        metrics = aggregated_metrics
+            aggregated_metrics = {}
+            for k in metrics:
+                aggregated_metrics[k] = {
+                    "total": distutils.all_reduce(
+                        metrics[k]["total"], average=False, device=self.device
+                    ),
+                    "numel": distutils.all_reduce(
+                        metrics[k]["numel"], average=False, device=self.device
+                    ),
+                }
+                aggregated_metrics[k]["metric"] = (
+                    aggregated_metrics[k]["total"]
+                    / aggregated_metrics[k]["numel"]
+                )
+            metrics = aggregated_metrics
 
-        log_dict = {k: metrics[k]["metric"] for k in metrics}
-        log_dict.update({"epoch": epoch + 1})
-        if distutils.is_master():
-            log_str = ["{}: {:.4f}".format(k, v) for k, v in log_dict.items()]
-            print(", ".join(log_str))
+            log_dict = {k: metrics[k]["metric"] for k in metrics}
+            log_dict.update({"epoch": epoch + 1})
+            if distutils.is_master():
+                log_str = [
+                    "{}: {:.4f}".format(k, v) for k, v in log_dict.items()
+                ]
+                print(", ".join(log_str))
 
-        # Make plots.
-        if self.logger is not None and epoch is not None:
-            self.logger.log(
-                log_dict,
-                step=(epoch + 1) * len(self.train_loader),
-                split=split,
-            )
+            # Make plots.
+            if self.logger is not None and epoch is not None:
+                self.logger.log(
+                    log_dict,
+                    step=(epoch + 1) * len(self.train_loader),
+                    split=split,
+                )
 
         return metrics
 

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -473,14 +473,11 @@ class BaseTrainer:
 
             self.scheduler.step()
 
-            with torch.no_grad():
-                if self.val_loader is not None:
-                    v_loss, v_mae = self.validate(split="val", epoch=epoch)
+            if self.val_loader is not None:
+                v_loss, v_mae = self.validate(split="val", epoch=epoch)
 
-                if self.test_loader is not None:
-                    test_loss, test_mae = self.validate(
-                        split="test", epoch=epoch
-                    )
+            if self.test_loader is not None:
+                test_loss, test_mae = self.validate(split="test", epoch=epoch)
 
             if not self.is_debug:
                 save_checkpoint(

--- a/ocpmodels/trainers/energy_trainer.py
+++ b/ocpmodels/trainers/energy_trainer.py
@@ -176,6 +176,7 @@ class EnergyTrainer(BaseTrainer):
             else:
                 raise NotImplementedError
 
+    @torch.no_grad()
     def predict(self, loader, results_file=None, disable_tqdm=False):
         if distutils.is_master() and not disable_tqdm:
             print("### Predicting on test.")

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -248,6 +248,7 @@ class ForcesTrainer(BaseTrainer):
             self.logger.log_plots(plots)
 
     # Takes in a new data source and generates predictions on it.
+    @torch.no_grad()
     def predict(
         self, data_loader, per_image=True, results_file=None, disable_tqdm=True
     ):

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -440,6 +440,9 @@ class ForcesTrainer(BaseTrainer):
                 if self.update_lr_on_step:
                     self.scheduler.step()
 
+                if i == 9:
+                    break
+
             if not self.update_lr_on_step:
                 self.scheduler.step()
 

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -440,9 +440,6 @@ class ForcesTrainer(BaseTrainer):
                 if self.update_lr_on_step:
                     self.scheduler.step()
 
-                if i == 9:
-                    break
-
             if not self.update_lr_on_step:
                 self.scheduler.step()
 


### PR DESCRIPTION
Validation memory usage is higher than that of training. This PR resolves this issue. 

Using the same dataset for train/val with `shuffle=False`, I benchmarked 10 updates of train/val respectively (allocated in MB):

Pre-Fix:
```
allocated 3324.904448
allocated 4519.053312
allocated 2300.791808
allocated 2240.774144
allocated 4299.392
allocated 3382.70976
allocated 4030.028288
allocated 4143.101952
allocated 3183.919616

### Evaluating on val.
allocated 3353.640448
allocated 6638.859776
allocated 7822.145024
allocated 6824.054784
allocated 4529.233408
allocated 6493.454848
allocated 7634.866176
allocated 7393.4976
allocated 8142.780416
allocated 7296.930304

forcesx_mae 0.07260803263042843
forcesy_mae 0.07774501425125371
forcesz_mae 0.0779459377799158
forces_mae 0.07609966071247863
forces_cos 0.018825592618360327
forces_magnitude 0.15358252428952493
energy_mae 2.4544071645402483
energy_force_within_threshold 0.0
loss 6.193538162198024
```

Post-Fix:
```
allocated 3324.904448
allocated 4519.053312
allocated 2300.791808
allocated 2240.774144
allocated 4299.392
allocated 3382.70976
allocated 4030.028288
allocated 4143.101952
allocated 3183.919616

### Evaluating on val.
allocated 1706.028544
allocated 1693.305856
allocated 2306.546176
allocated 1185.345536
allocated 1137.897984
allocated 2180.798976
allocated 1722.000384
allocated 2057.613824
allocated 2106.560512
allocated 1630.085632

forcesx_mae 0.07260803263042843
forcesy_mae 0.07774501379231516
forcesz_mae 0.0779459377799158
forces_mae 0.07609966071247863
forces_cos 0.01882559651933804
forces_magnitude 0.15358252428952493
energy_mae 2.4544071642142855
energy_force_within_threshold 0.0
loss 6.193538161872061
```

Open to suggestions to alternate ways to wrap the model forward pass while capturing the same functionality.

