### PR TITLE
conditional decorator for energy/force trainers

### DIFF
--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -14,7 +14,6 @@ import json
 import os
 import time
 from bisect import bisect
-from functools import wraps
 from itertools import product
 
 import demjson

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -14,6 +14,7 @@ import json
 import os
 import time
 from bisect import bisect
+from functools import wraps
 from itertools import product
 
 import demjson
@@ -77,6 +78,21 @@ def print_cuda_usage():
     )
     print("Memory Cached:", torch.cuda.memory_cached() / (1024 * 1024))
     print("Max Memory Cached:", torch.cuda.max_memory_cached() / (1024 * 1024))
+
+
+def conditional_grad(dec):
+    "Decorator to enable/disable grad depending on whether force/energy predictions are being made"
+    # Adapted from https://stackoverflow.com/questions/60907323/accessing-class-property-as-decorator-argument
+    def decorator(func):
+        def cls_method(self, *args, **kwargs):
+            f = func
+            if self.regress_forces:
+                f = dec(func)
+            return f(self, *args, **kwargs)
+
+        return cls_method
+
+    return decorator
 
 
 def plot_histogram(data, xlabel="", ylabel="", title=""):

--- a/ocpmodels/models/cgcnn.py
+++ b/ocpmodels/models/cgcnn.py
@@ -11,7 +11,11 @@ from torch_geometric.nn import MessagePassing, global_mean_pool, radius_graph
 from torch_geometric.nn.models.schnet import GaussianSmearing
 
 from ocpmodels.common.registry import registry
-from ocpmodels.common.utils import get_pbc_distances, radius_graph_pbc
+from ocpmodels.common.utils import (
+    conditional_grad,
+    get_pbc_distances,
+    radius_graph_pbc,
+)
 from ocpmodels.datasets.embeddings import KHOT_EMBEDDINGS
 from ocpmodels.models.base import BaseModel
 
@@ -101,7 +105,7 @@ class CGCNN(BaseModel):
         self.cutoff = cutoff
         self.distance_expansion = GaussianSmearing(0.0, cutoff, num_gaussians)
 
-    @torch.enable_grad()
+    @conditional_grad(torch.enable_grad())
     def _forward(self, data):
         # Get node features
         if self.embedding.device != data.atomic_numbers.device:

--- a/ocpmodels/models/dimenet.py
+++ b/ocpmodels/models/dimenet.py
@@ -11,7 +11,11 @@ from torch_geometric.nn import DimeNet, radius_graph
 from torch_scatter import scatter
 
 from ocpmodels.common.registry import registry
-from ocpmodels.common.utils import get_pbc_distances, radius_graph_pbc
+from ocpmodels.common.utils import (
+    conditional_grad,
+    get_pbc_distances,
+    radius_graph_pbc,
+)
 
 
 @registry.register_model("dimenet")
@@ -100,7 +104,7 @@ class DimeNetWrap(DimeNet):
             num_output_layers=num_output_layers,
         )
 
-    @torch.enable_grad()
+    @conditional_grad(torch.enable_grad())
     def _forward(self, data):
         pos = data.pos
         batch = data.batch

--- a/ocpmodels/models/dimenet_plus_plus.py
+++ b/ocpmodels/models/dimenet_plus_plus.py
@@ -48,7 +48,11 @@ from torch_scatter import scatter
 from torch_sparse import SparseTensor
 
 from ocpmodels.common.registry import registry
-from ocpmodels.common.utils import get_pbc_distances, radius_graph_pbc
+from ocpmodels.common.utils import (
+    conditional_grad,
+    get_pbc_distances,
+    radius_graph_pbc,
+)
 
 try:
     import sympy as sym
@@ -370,7 +374,7 @@ class DimeNetPlusPlusWrap(DimeNetPlusPlus):
             num_output_layers=num_output_layers,
         )
 
-    @torch.enable_grad()
+    @conditional_grad(torch.enable_grad())
     def _forward(self, data):
         pos = data.pos
         batch = data.batch

--- a/ocpmodels/models/schnet.py
+++ b/ocpmodels/models/schnet.py
@@ -10,7 +10,11 @@ from torch_geometric.nn import SchNet
 from torch_scatter import scatter
 
 from ocpmodels.common.registry import registry
-from ocpmodels.common.utils import get_pbc_distances, radius_graph_pbc
+from ocpmodels.common.utils import (
+    conditional_grad,
+    get_pbc_distances,
+    radius_graph_pbc,
+)
 
 
 @registry.register_model("schnet")
@@ -79,7 +83,7 @@ class SchNetWrap(SchNet):
             readout=readout,
         )
 
-    @torch.enable_grad()
+    @conditional_grad(torch.enable_grad())
     def _forward(self, data):
         z = data.atomic_numbers.long()
         pos = data.pos


### PR DESCRIPTION
Small optimization to #199 - Previous PR always had `torch.enable_grad()` for the forward pass, even for models making only energy predictions...which was unnecessary. This PR defines a custom decorator to switch between the two settings depending on whether forces are being regressed or not. 

Profiling GPU usage (MB) for energy predictions:

PR #199:
```
allocated 2474.7626953125
allocated 1377.052734375
allocated 2080.26708984375
allocated 1914.98486328125
allocated 1480.64892578125
allocated 1414.263671875
allocated 1962.06591796875
allocated 1587.49658203125
allocated 1823.33203125
allocated 2392.71630859375
allocated 2108.71044921875
allocated 1719.5595703125
allocated 1435.11962890625
allocated 1764.458984375
allocated 1667.7919921875
allocated 1408.41943359375
allocated 2131.3740234375
allocated 1977.72705078125
allocated 1217.40966796875
allocated 1936.044921875
```

this fix:
```
allocated 71.9130859375
allocated 80.49072265625
allocated 69.6572265625
allocated 80.517578125
allocated 66.1376953125
allocated 74.10498046875
allocated 68.97998046875
allocated 77.9345703125
allocated 68.14501953125
allocated 81.7529296875
allocated 69.83984375
allocated 79.56787109375
allocated 65.859375
allocated 75.85498046875
allocated 68.08056640625
allocated 75.9951171875
allocated 69.93994140625
allocated 81.1708984375
allocated 64.58984375
allocated 75.61328125
```