### PR TITLE
flag to load ddp cp without ddp

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,7 +56,7 @@ class Runner(submitit.helpers.Checkpointable):
                 cpu=config.get("cpu", False),
             )
             if config["checkpoint"] is not None:
-                trainer.load_pretrained(config["checkpoint"])
+                trainer.load_pretrained(config["checkpoint"], config["nonddp"])
 
             # save checkpoint path to runner state for slurm resubmissions
             self.chkpt_path = os.path.join(

--- a/ocpmodels/common/flags.py
+++ b/ocpmodels/common/flags.py
@@ -76,6 +76,11 @@ class Flags:
         self.parser.add_argument(
             "--checkpoint", type=str, help="Model checkpoint to load"
         )
+        self.parser.add_argument(
+            "--nonddp",
+            action="store_true",
+            help="Load model checkpoint without DDP",
+        )
         # Cluster args
         self.parser.add_argument(
             "--sweep-yml",

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -288,6 +288,7 @@ def build_config(args, args_override):
     config["is_vis"] = args.vis
     config["print_every"] = args.print_every
     config["amp"] = args.amp
+    config["nonddp"] = args.nonddp
     config["checkpoint"] = args.checkpoint
     config["cpu"] = args.cpu
     # Submit


### PR DESCRIPTION
Follow up to - https://github.com/Open-Catalyst-Project/ocp/issues/174.

Includes a flag to make this easily modified without having people change the source code.

To load our DDP pretrained checkpoints with only 1 GPU:
`python main.py --mode ... --config-yml ... --checkpoint ... --nonddp`