### PR TITLE
Upgrades to pytorch 1.7.1, pytorch-geometric 1.6.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
 
       - restore_cache:
           keys:
-          - v0.2-dependencies-{{ checksum "env.common.yml" }}-{{ checksum "env.cpu.yml" }}-{{ checksum "env.gpu.yml" }}
+          - v0.3-dependencies-{{ checksum "env.common.yml" }}-{{ checksum "env.cpu.yml" }}-{{ checksum "env.gpu.yml" }}
 
       - run:
           name: Install conda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - save_cache:
           paths:
             - /home/circleci/miniconda
-          key: v0.2-dependencies-{{ checksum "env.common.yml" }}-{{ checksum "env.cpu.yml" }}-{{ checksum "env.gpu.yml" }}
+          key: v0.3-dependencies-{{ checksum "env.common.yml" }}-{{ checksum "env.cpu.yml" }}-{{ checksum "env.gpu.yml" }}
 
       - run:
           name: Run tests

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ input to predict material properties:
 
 ##  Installation
 
-[last updated December 09, 2020]
+[last updated March 04, 2021]
 
 The easiest way of installing prerequisites is via [conda](https://conda.io/docs/index.html).
 After installing [conda](http://conda.pydata.org/), run the following commands
@@ -27,14 +27,14 @@ Check that you can invoke `conda-merge` by running `conda-merge -h`.
 
 ### GPU machines
 
-Instructions are for PyTorch 1.6, CUDA 10.1 specifically.
+Instructions are for PyTorch 1.7.1, CUDA 11.0 specifically.
 
 First, check that CUDA is in your `PATH` and `LD_LIBRARY_PATH`, e.g.
 ```
 $echo $PATH | tr ':' '\n' | grep cuda
-/public/apps/cuda/10.1/bin
+/public/apps/cuda/11.0/bin
 $echo $LD_LIBRARY_PATH | tr ':' '\n' | grep cuda
-/public/apps/cuda/10.1/lib64
+/public/apps/cuda/11.0/lib64
 ```
 The exact paths may differ on your system. Then install the dependencies:
 ```bash

--- a/env.common.yml
+++ b/env.common.yml
@@ -5,16 +5,15 @@ channels:
   - defaults
 dependencies:
   - ase=3.19.*
-  - gpytorch
   - matplotlib=3.3.*
   - pip
-  - pre-commit=2.2.*
+  - pre-commit=2.10.*
   - pymatgen=2020.8.13
   - python=3.6.*
-  - pytorch=1.6.0
-  - pyyaml=5.3.*
-  - tensorboard=1.15.*
-  - tqdm=4.45.*
+  - pytorch=1.7.1
+  - pyyaml=5.4.*
+  - tensorboard=2.4.*
+  - tqdm=4.58.*
   - sphinx
   - nbsphinx
   - pandoc
@@ -23,9 +22,9 @@ dependencies:
     - demjson
     - Pillow
     - ray[tune]
-    - torch-geometric==1.6.1
+    - torch-geometric==1.6.3
     - wandb
-    - lmdb==1.0.0
-    - pytest==5.4.3
+    - lmdb==1.1.1
+    - pytest==6.2.2
     - submitit
     - sphinx-rtd-theme

--- a/env.common.yml
+++ b/env.common.yml
@@ -4,11 +4,11 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - ase=3.19.*
+  - ase=3.21.*
   - matplotlib=3.3.*
   - pip
   - pre-commit=2.10.*
-  - pymatgen=2020.8.13
+  - pymatgen=2021.12.31
   - python=3.6.*
   - pytorch=1.7.1
   - pyyaml=5.4.*

--- a/env.common.yml
+++ b/env.common.yml
@@ -8,7 +8,7 @@ dependencies:
   - matplotlib=3.3.*
   - pip
   - pre-commit=2.10.*
-  - pymatgen=2021.12.31
+  - pymatgen=2020.12.31
   - python=3.6.*
   - pytorch=1.7.1
   - pyyaml=5.4.*

--- a/env.cpu.yml
+++ b/env.cpu.yml
@@ -1,7 +1,7 @@
 dependencies:
   - cpuonly
   - pip:
-    - -f https://pytorch-geometric.com/whl/torch-1.6.0+cpu.html
+    - -f https://pytorch-geometric.com/whl/torch-1.7.0+cpu.html
     - torch-cluster
     - torch-scatter
     - torch-sparse

--- a/env.gpu.yml
+++ b/env.gpu.yml
@@ -3,9 +3,9 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - cudatoolkit=10.1
+  - cudatoolkit=11.0
   - pip:
-    - -f https://pytorch-geometric.com/whl/torch-1.6.0+cu101.html
+    - -f https://pytorch-geometric.com/whl/torch-1.7.0+cu110.html
     - torch-cluster
     - torch-scatter
     - torch-sparse

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ from setuptools import find_packages, setup
 
 setup(
     name="ocp-models",
-    version="0.0.1",
-    description="A machine learning package for molecular systems involved with catalysis",
-    url="https://github.com/Open-Catalyst-Project/baselines",
+    version="0.0.2",
+    description="Machine learning models for use in catalysis as part of the Open Catalyst Project",
+    url="https://github.com/Open-Catalyst-Project/ocp",
     packages=find_packages(),
     include_package_data=True,
 )


### PR DESCRIPTION
Still testing this out.

- Upgraded to pytorch 1.7.1, pytorch-geometric 1.6.3
- Dropped `gpytorch` as a dependency since we no longer use it in `master`. Can add it back if we use it in future.
- Upgraded `ase` to 3.21.* and `pymatgen` to 2021.12.31