### PR TITLE
Optimizer flexibility 

### DIFF
--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -397,8 +397,8 @@ class BaseTrainer:
         optimizer = getattr(optim, optimizer)
 
         self.optimizer = optimizer(
-            self.model.parameters(),
-            self.config["optim"]["lr_initial"],
+            params=self.model.parameters(),
+            lr=self.config["optim"]["lr_initial"],
             **self.config["optim"].get("optimizer_params", {}),
         )
 

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -393,9 +393,13 @@ class BaseTrainer:
         self.criterion = self.config["optim"].get("criterion", nn.L1Loss())
 
     def load_optimizer(self):
-        self.optimizer = optim.AdamW(
+        optimizer = self.config["optim"].get("optimizer", "AdamW")
+        optimizer = getattr(optim, optimizer)
+
+        self.optimizer = optimizer(
             self.model.parameters(),
-            self.config["optim"]["lr_initial"],  # weight_decay=3.0
+            self.config["optim"]["lr_initial"],
+            **self.config["optim"].get("optimizer_params", {}),
         )
 
     def load_extras(self):


### PR DESCRIPTION
Allows for optimizer+optimizer params to be defined at the config level. Still defaults to `AdamW`.

Necessary for replicating alternative models' performance with different optimizer. A future PR will also customize schedulers as well. 