### PR TITLE
Add DDP support on top of pipeline parallel

### DIFF
--- a/configs/s2ef/200k/forcenet/fn_forceonly_sequential_fair.yml
+++ b/configs/s2ef/200k/forcenet/fn_forceonly_sequential_fair.yml
@@ -6,7 +6,7 @@ dataset:
 
 model:
   name: forcenet_sequential
-  num_interactions: 14
+  num_interactions: 3
   cutoff: 6
   basis: "sphallmul"
   ablation: "none"
@@ -18,10 +18,10 @@ model:
   hidden_channels: 64
   decoder_hidden_channels: 128
   max_n: 3
-  pipeline_parallel_chunks: 8
-  pipeline_parallel_balance: [ 3, 2, 2, 2, 2, 2, 2, 2 ]
-  pipeline_parallel_devices: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
-  pipeline_parallel_checkpoint: "never"
+  pipeline_parallel_chunks: 2
+  pipeline_parallel_balance: [ 3, 3 ]
+  pipeline_parallel_devices: [ 0, 1 ]
+  pipeline_parallel_checkpoint: "always"
 
 #hidden_channels: 6144
 # decoder_hidden_channels: 15360
@@ -29,7 +29,7 @@ model:
 optim:
   batch_size: 8
   eval_batch_size: 1
-  eval_every: 1
+  eval_every: 10
   num_workers: 64
   lr_initial: 0.0005
   max_epochs: 20

--- a/main.py
+++ b/main.py
@@ -128,7 +128,7 @@ if __name__ == "__main__":
             slurm_partition=args.slurm_partition,
             gpus_per_node=args.num_gpus,
             cpus_per_task=(args.num_workers + 1),
-            tasks_per_node=(args.num_gpus if args.distributed else 1),
+            tasks_per_node=1,  # (args.num_gpus if args.distributed else 1), For DDP at inter-node-level, we only need to launch one task per node; intra-node computation will happen via pipeline parallelism
             nodes=args.num_nodes,
         )
         jobs = executor.map_array(Runner(), configs)

--- a/ocpmodels/common/distutils.py
+++ b/ocpmodels/common/distutils.py
@@ -35,6 +35,17 @@ def setup(config):
                     nnodes = int(os.environ.get("SLURM_NNODES"))
                     assert ntasks % nnodes == 0
                     ntasks_per_node = int(ntasks / nnodes)
+
+                ## Hardcoding for now to enable pipeline parallel + DDP
+                node_id = int(os.environ.get("SLURM_NODEID"))
+                local_id = int(os.environ.get("SLURM_LOCALID"))
+                config["rank"] = node_id
+                config["local_rank"] = local_id
+
+                if local_id == 0:
+                    torch.cuda.set_device(local_id)
+
+                """
                 if ntasks_per_node == 1:
                     assert config["world_size"] % nnodes == 0
                     gpus_per_node = config["world_size"] // nnodes
@@ -45,7 +56,7 @@ def setup(config):
                     assert ntasks_per_node == config["world_size"] // nnodes
                     config["rank"] = int(os.environ.get("SLURM_PROCID"))
                     config["local_rank"] = int(os.environ.get("SLURM_LOCALID"))
-
+                """
                 print(
                     "Init: ",
                     config["init_method"],

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -280,7 +280,9 @@ def build_config(args, args_override):
     # Distributed
     config["local_rank"] = args.local_rank
     config["distributed_port"] = args.distributed_port
-    config["world_size"] = args.num_nodes * args.num_gpus
+    config[
+        "world_size"
+    ] = args.num_nodes  # * args.num_gpus, hardcoding for PP + DDP
     config["distributed_backend"] = args.distributed_backend
 
     return config


### PR DESCRIPTION
This is the 3rd PR in the series to add pipeline parallel support for Forcenet. See https://github.com/Open-Catalyst-Project/ocp/pull/180 for the previous part.

Specifically, this PR adds DDP + PP support on forcenet.

Checkpointing + DDP doesn't work as we had discussed earlier. To fix this, I added a custom implementation to mimic DDP functionality.

Now DDP + PP + checkpointing works!

--------- 

For reference, if we use Pytorch DDP with PP + checkpointing, we get the following error (known issue):

```
Traceback (most recent call last):
  File "/private/home/sidgoyal/.conda/envs/ocp-models/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/private/home/sidgoyal/.conda/envs/ocp-models/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/private/home/sidgoyal/.conda/envs/ocp-models/lib/python3.6/site-packages/submitit/core/_submit.py", line 11, in <module>
    submitit_main()
  File "/private/home/sidgoyal/.conda/envs/ocp-models/lib/python3.6/site-packages/submitit/core/submission.py", line 65, in submitit_main
    process_job(args.folder)
  File "/private/home/sidgoyal/.conda/envs/ocp-models/lib/python3.6/site-packages/submitit/core/submission.py", line 58, in process_job
    raise error
  File "/private/home/sidgoyal/.conda/envs/ocp-models/lib/python3.6/site-packages/submitit/core/submission.py", line 47, in process_job
    result = delayed.result()
  File "/private/home/sidgoyal/.conda/envs/ocp-models/lib/python3.6/site-packages/submitit/core/utils.py", line 123, in result
    self._result = self.function(*self.args, **self.kwargs)
  File "main.py", line 69, in __call__
    trainer.train()
  File "/private/home/sidgoyal/ocp/ocpmodels/trainers/pipeline_parallel_trainer.py", line 358, in train
    self._backward(loss)
  File "/private/home/sidgoyal/ocp/ocpmodels/trainers/base_trainer.py", line 705, in _backward
    loss.backward()
  File "/private/home/sidgoyal/.conda/envs/ocp-models/lib/python3.6/site-packages/torch/tensor.py", line 185, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph)
  File "/private/home/sidgoyal/.conda/envs/ocp-models/lib/python3.6/site-packages/torch/autograd/__init__.py", line 127, in backward
    allow_unreachable=True)  # allow_unreachable flag
RuntimeError: Expected to mark a variable ready only once. This error is caused by one of the following reasons: 1) Use of a module parameter outside the `forward` function. Please make sure model parameters are not shared across multiple concurrent forward-backward passes2) Reused parameters in multiple reentrant backward passes. For example, if you use multiple `checkpoint` functions to wrap the same part of your model, it would result in the same set of parameters been used by different reentrant backward passes multiple times, and hence marking a variable ready multiple times. DDP does not support such use cases yet.3) Incorrect unused parameter detection. The return value of the `forward` function is inspected by the distributed data parallel wrapper to figure out if any of the module's parameters went unused. For unused parameters, DDP would not expect gradients from then. However, if an unused parameter becomes part of the autograd graph at a later point in time (e.g., in a reentrant backward when using `checkpoint`), the gradient will show up unexpectedly. If all parameters in the model participate in the backward pass, you can disable unused parameter detection by passing the keyword argument `find_unused_parameters=False` to `torch.nn.parallel.DistributedDataParallel`.

```
This doesn't get resolved even with `find_unused_parameters=False` argument.