### PR TITLE
Deterministic CI tests

### DIFF
--- a/tests/models/test_dimenet.py
+++ b/tests/models/test_dimenet.py
@@ -40,6 +40,7 @@ def load_data(request):
 
 @pytest.fixture(scope="class")
 def load_model(request):
+    torch.manual_seed(4)
     model = DimeNet(
         None,
         32,

--- a/tests/models/test_schnet.py
+++ b/tests/models/test_schnet.py
@@ -40,6 +40,7 @@ def load_data(request):
 
 @pytest.fixture(scope="class")
 def load_model(request):
+    torch.manual_seed(4)
     model = SchNet(None, 32, 1, cutoff=6.0, regress_forces=True, use_pbc=True)
     request.cls.model = model
 


### PR DESCRIPTION
Makes CI tests deterministic - preventing the need to restart a test with a failing bad seed (e.g. https://app.circleci.com/pipelines/github/Open-Catalyst-Project/ocp/452/workflows/449c0c03-38fc-4d4d-a550-98e17f0aa642/jobs/500).

Also adds DimeNet++ for completeness.