### PR TITLE
Add null scheduler

### DIFF
--- a/ocpmodels/modules/scheduler.py
+++ b/ocpmodels/modules/scheduler.py
@@ -1,7 +1,6 @@
 import inspect
 
 import torch.optim.lr_scheduler as lr_scheduler
-
 from ocpmodels.common.utils import warmup_lr_lambda
 
 
@@ -9,11 +8,11 @@ class LRScheduler:
     """
     Learning rate scheduler class for torch.optim learning rate schedulers
 
-    .. note::
+    Notes:
         If no learning rate scheduler is specified in the config the default
         scheduler is warmup_lr_lambda (ocpmodels.common.utils) not no scheduler,
         this is for backward-compatibility reasons. To run without a lr scheduler
-        specify scheduler: Null in the optim section of the config.
+        specify scheduler: "Null" in the optim section of the config.
 
     Args:
         config (dict): Optim dict from the input config

--- a/ocpmodels/modules/scheduler.py
+++ b/ocpmodels/modules/scheduler.py
@@ -6,6 +6,20 @@ from ocpmodels.common.utils import warmup_lr_lambda
 
 
 class LRScheduler:
+    """
+    Learning rate scheduler class for torch.optim learning rate schedulers
+
+    .. note::
+        If no learning rate scheduler is specified in the config the default
+        scheduler is warmup_lr_lambda (ocpmodels.common.utils) not no scheduler,
+        this is for backward-compatibility reasons. To run without a lr scheduler
+        specify scheduler: Null in the optim section of the config.
+
+    Args:
+        config (dict): Optim dict from the input config
+        optimizer (obj): torch optim object
+    """
+
     def __init__(self, optimizer, config):
         self.optimizer = optimizer
         self.config = config.copy()

--- a/ocpmodels/modules/scheduler.py
+++ b/ocpmodels/modules/scheduler.py
@@ -16,11 +16,14 @@ class LRScheduler:
             scheduler_lambda_fn = lambda x: warmup_lr_lambda(x, self.config)
             self.config["lr_lambda"] = scheduler_lambda_fn
 
-        self.scheduler = getattr(lr_scheduler, self.scheduler_type)
-        scheduler_args = self.filter_kwargs(config)
-        self.scheduler = self.scheduler(optimizer, **scheduler_args)
+        if self.scheduler_type != "Null":
+            self.scheduler = getattr(lr_scheduler, self.scheduler_type)
+            scheduler_args = self.filter_kwargs(config)
+            self.scheduler = self.scheduler(optimizer, **scheduler_args)
 
     def step(self, metrics=None, epoch=None):
+        if self.scheduler_type == "Null":
+            return
         if self.scheduler_type == "ReduceLROnPlateau":
             if not metrics:
                 raise Exception(

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -376,7 +376,7 @@ class BaseTrainer:
             self.model.load_state_dict(checkpoint["state_dict"])
 
         self.optimizer.load_state_dict(checkpoint["optimizer"])
-        if "scheduler" in checkpoint:
+        if checkpoint["scheduler"]:
             self.scheduler.scheduler.load_state_dict(checkpoint["scheduler"])
 
         for key in checkpoint["normalizers"]:
@@ -419,7 +419,9 @@ class BaseTrainer:
                     "step": step,
                     "state_dict": self.model.state_dict(),
                     "optimizer": self.optimizer.state_dict(),
-                    "scheduler": self.scheduler.scheduler.state_dict(),
+                    "scheduler": self.scheduler.scheduler.state_dict()
+                    if self.scheduler.scheduler_type != "Null"
+                    else None,
                     "normalizers": {
                         key: value.state_dict()
                         for key, value in self.normalizers.items()


### PR DESCRIPTION
This is part two of #232

Implementation of a null scheduler for constant learning rate:

- no torch.optim.lr_scheduler is instantiated
- on scheduler.step() nothing happens
- logic is added so the scheduler.state_dict() is not saved or loaded 

Features:

- ability to run without a learning rate scheduler — one use case is population based training with Ray Tune