### PR TITLE
Fix/update to scheduler module

### DIFF
--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -58,16 +58,16 @@ class Complete(object):
         return data
 
 
-def warmup_lr_lambda(current_epoch, optim_config):
+def warmup_lr_lambda(current_step, optim_config):
     """Returns a learning rate multiplier.
-    Till `warmup_epochs`, learning rate linearly increases to `initial_lr`,
+    Till `warmup_steps`, learning rate linearly increases to `initial_lr`,
     and then gets multiplied by `lr_gamma` every time a milestone is crossed.
     """
-    if current_epoch <= optim_config["warmup_epochs"]:
-        alpha = current_epoch / float(optim_config["warmup_epochs"])
+    if current_step <= optim_config["warmup_steps"]:
+        alpha = current_step / float(optim_config["warmup_steps"])
         return optim_config["warmup_factor"] * (1.0 - alpha) + alpha
     else:
-        idx = bisect(optim_config["lr_milestones"], current_epoch)
+        idx = bisect(optim_config["lr_milestones"], current_step)
         return pow(optim_config["lr_gamma"], idx)
 
 

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -63,6 +63,15 @@ def warmup_lr_lambda(current_step, optim_config):
     Till `warmup_steps`, learning rate linearly increases to `initial_lr`,
     and then gets multiplied by `lr_gamma` every time a milestone is crossed.
     """
+
+    # keep this block for backward compatibility to older checkpoints that
+    # have warmup_epochs instead of warmup_steps.
+    if "warmup_steps" not in optim_config:
+        print(
+            "WARNING: warmup_steps not specified in config. Setting it equal to warmup_epochs."
+        )
+        optim_config["warmup_steps"] = optim_config["warmup_epochs"]
+
     if current_step <= optim_config["warmup_steps"]:
         alpha = current_step / float(optim_config["warmup_steps"])
         return optim_config["warmup_factor"] * (1.0 - alpha) + alpha

--- a/ocpmodels/modules/scheduler.py
+++ b/ocpmodels/modules/scheduler.py
@@ -22,7 +22,7 @@ class LRScheduler:
 
     def step(self, metrics=None, epoch=None):
         if self.scheduler_type == "ReduceLROnPlateau":
-            if not metrics:
+            if metrics is None:
                 raise Exception(
                     "Validation set required for ReduceLROnPlateau."
                 )

--- a/ocpmodels/modules/scheduler.py
+++ b/ocpmodels/modules/scheduler.py
@@ -19,12 +19,6 @@ class LRScheduler:
         self.scheduler = getattr(lr_scheduler, self.scheduler_type)
         scheduler_args = self.filter_kwargs(config)
         self.scheduler = self.scheduler(optimizer, **scheduler_args)
-        # sets the learning rate update type i.e. update on step, epoch, or val
-        (
-            self.update_lr_on_step,
-            self.update_lr_on_epoch,
-            self.update_lr_on_val,
-        ) = self.set_lr_update_type(self.config)
 
     def step(self, metrics=None, epoch=None):
         if self.scheduler_type == "ReduceLROnPlateau":
@@ -48,32 +42,6 @@ class LRScheduler:
             arg: self.config[arg] for arg in self.config if arg in filter_keys
         }
         return scheduler_args
-
-    @staticmethod
-    def set_lr_update_type(config):
-
-        update_lr_on_step = False
-        update_lr_on_epoch = False
-        update_lr_on_val = False
-
-        if "update_lr_on" in config:
-            # checks for allowed strings
-            if config["update_lr_on"] in ["step", "epoch", "val"]:
-                if config["update_lr_on"] == "step":
-                    update_lr_on_step = True
-                if config["update_lr_on"] == "epoch":
-                    update_lr_on_epoch = True
-                if config["update_lr_on"] == "val":
-                    update_lr_on_val = True
-            else:
-                raise Exception(
-                    "update_lr_on in the config expects one of following strings: step, epoch, or val"
-                )
-        # If update_lr_on is not defined in the config default is update_lr_on_epoch
-        else:
-            update_lr_on_epoch = True
-
-        return update_lr_on_step, update_lr_on_epoch, update_lr_on_val
 
     def get_lr(self):
         for group in self.optimizer.param_groups:

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -9,6 +9,7 @@ import json
 import os
 import random
 import subprocess
+from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict
 from pathlib import Path
 
@@ -38,7 +39,7 @@ from ocpmodels.modules.scheduler import LRScheduler
 
 
 @registry.register_trainer("base")
-class BaseTrainer:
+class BaseTrainer(ABC):
     def __init__(
         self,
         task,
@@ -233,80 +234,9 @@ class BaseTrainer:
                 self.config
             )
 
+    @abstractmethod
     def load_task(self):
-        print("### Loading dataset: {}".format(self.config["task"]["dataset"]))
-        dataset = registry.get_dataset_class(self.config["task"]["dataset"])(
-            self.config["dataset"]
-        )
-
-        if self.config["task"]["dataset"] in ["qm9", "dogss"]:
-            num_targets = dataset.data.y.shape[-1]
-            if (
-                "label_index" in self.config["task"]
-                and self.config["task"]["label_index"] is not False
-            ):
-                dataset.data.y = dataset.data.y[
-                    :, int(self.config["task"]["label_index"])
-                ]
-                num_targets = 1
-        else:
-            num_targets = 1
-
-        self.num_targets = num_targets
-        (
-            self.train_loader,
-            self.val_loader,
-            self.test_loader,
-        ) = dataset.get_dataloaders(
-            batch_size=int(self.config["optim"]["batch_size"])
-        )
-
-        # Normalizer for the dataset.
-        # Compute mean, std of training set labels.
-        self.normalizers = {}
-        if self.config["dataset"].get("normalize_labels", True):
-            self.normalizers["target"] = Normalizer(
-                self.train_loader.dataset.data.y[
-                    self.train_loader.dataset.__indices__
-                ],
-                self.device,
-            )
-
-        # If we're computing gradients wrt input, set mean of normalizer to 0 --
-        # since it is lost when compute dy / dx -- and std to forward target std
-        if "grad_input" in self.config["task"]:
-            if self.config["dataset"].get("normalize_labels", True):
-                self.normalizers["grad_target"] = Normalizer(
-                    self.train_loader.dataset.data.y[
-                        self.train_loader.dataset.__indices__
-                    ],
-                    self.device,
-                )
-                self.normalizers["grad_target"].mean.fill_(0)
-
-        if self.is_vis and self.config["task"]["dataset"] != "qm9":
-            # Plot label distribution.
-            plots = [
-                plot_histogram(
-                    self.train_loader.dataset.data.y.tolist(),
-                    xlabel="{}/raw".format(self.config["task"]["labels"][0]),
-                    ylabel="# Examples",
-                    title="Split: train",
-                ),
-                plot_histogram(
-                    self.val_loader.dataset.data.y.tolist(),
-                    xlabel="{}/raw".format(self.config["task"]["labels"][0]),
-                    ylabel="# Examples",
-                    title="Split: val",
-                ),
-                plot_histogram(
-                    self.test_loader.dataset.data.y.tolist(),
-                    xlabel="{}/raw".format(self.config["task"]["labels"][0]),
-                    ylabel="# Examples",
-                    title="Split: test",
-                ),
-            ]
-            self.logger.log_plots(plots)
+        """ Derived classes should implement this function."""
 
     def load_model(self):
         # Build model
@@ -432,84 +362,9 @@ class BaseTrainer:
                 self.config["cmd"]["checkpoint_dir"],
             )
 
-    def train(self, max_epochs=None, return_metrics=False):
-        # TODO(abhshkdz): Timers for dataloading and forward pass.
-        num_epochs = (
-            max_epochs
-            if max_epochs is not None
-            else self.config["optim"]["max_epochs"]
-        )
-        for epoch in range(num_epochs):
-            self.model.train()
-
-            for i, batch in enumerate(self.train_loader):
-                batch = batch.to(self.device)
-
-                # Forward, loss, backward.
-                out, metrics = self._forward(batch)
-                loss = self._compute_loss(out, batch)
-                self._backward(loss)
-
-                # Update meter.
-                meter_update_dict = {
-                    "epoch": epoch + (i + 1) / len(self.train_loader),
-                    "loss": loss.item(),
-                }
-                meter_update_dict.update(metrics)
-                self.meter.update(meter_update_dict)
-
-                # Make plots.
-                if self.logger is not None:
-                    self.logger.log(
-                        meter_update_dict,
-                        step=epoch * len(self.train_loader) + i + 1,
-                        split="train",
-                    )
-
-                # Print metrics.
-                if i % self.config["cmd"]["print_every"] == 0:
-                    print(self.meter)
-
-            self.scheduler.step()
-
-            if self.val_loader is not None:
-                v_loss, v_mae = self.validate(split="val", epoch=epoch)
-
-            if self.test_loader is not None:
-                test_loss, test_mae = self.validate(split="test", epoch=epoch)
-
-            if not self.is_debug:
-                save_checkpoint(
-                    {
-                        "epoch": epoch + 1,
-                        "state_dict": self.model.state_dict(),
-                        "optimizer": self.optimizer.state_dict(),
-                        "normalizers": {
-                            key: value.state_dict()
-                            for key, value in self.normalizers.items()
-                        },
-                        "config": self.config,
-                        "amp": self.scaler.state_dict()
-                        if self.scaler
-                        else None,
-                    },
-                    self.config["cmd"]["checkpoint_dir"],
-                )
-        if return_metrics:
-            return {
-                "training_loss": float(self.meter.loss.global_avg),
-                "training_mae": float(
-                    self.meter.meters[
-                        self.config["task"]["labels"][0]
-                        + "/"
-                        + self.config["task"]["metric"]
-                    ].global_avg
-                ),
-                "validation_loss": v_loss,
-                "validation_mae": v_mae,
-                "test_loss": test_loss,
-                "test_mae": test_mae,
-            }
+    @abstractmethod
+    def train(self):
+        """ Derived classes should implement this function."""
 
     @torch.no_grad()
     def validate(self, split="val", epoch=None, disable_tqdm=False):
@@ -571,151 +426,13 @@ class BaseTrainer:
 
         return metrics
 
-    def _forward(self, batch, compute_metrics=True):
-        out = {}
+    @abstractmethod
+    def _forward(self, batch_list):
+        """ Derived classes should implement this function."""
 
-        # enable gradient wrt input.
-        if "grad_input" in self.config["task"]:
-            inp_for_grad = batch.pos
-            batch.pos = batch.pos.requires_grad_(True)
-
-        # forward pass.
-        if self.config["model_attributes"].get("regress_forces", False):
-            output, output_forces = self.model(batch)
-        else:
-            output = self.model(batch)
-
-        if output.shape[-1] == 1:
-            output = output.view(-1)
-
-        out["output"] = output
-
-        force_output = None
-        if self.config["model_attributes"].get("regress_forces", False):
-            out["force_output"] = output_forces
-            force_output = output_forces
-
-        if (
-            "grad_input" in self.config["task"]
-            and self.config["model_attributes"].get("regress_forces", False)
-            is False
-        ):
-            force_output = -1 * torch.autograd.grad(
-                output,
-                inp_for_grad,
-                grad_outputs=torch.ones_like(output),
-                create_graph=True,
-                retain_graph=True,
-            )[0]
-            out["force_output"] = force_output
-
-        if not compute_metrics:
-            return out, None
-
-        metrics = {}
-
-        if self.config["dataset"].get("normalize_labels", True):
-            errors = eval(self.config["task"]["metric"])(
-                self.normalizers["target"].denorm(output).cpu(), batch.y.cpu()
-            ).view(-1)
-        else:
-            errors = eval(self.config["task"]["metric"])(
-                output.cpu(), batch.y.cpu()
-            ).view(-1)
-
-        if (
-            "label_index" in self.config["task"]
-            and self.config["task"]["label_index"] is not False
-        ):
-            # TODO(abhshkdz): Get rid of this edge case for QM9.
-            # This is only because QM9 has multiple targets and we can either
-            # jointly predict all of them or one particular target.
-            metrics[
-                "{}/{}".format(
-                    self.config["task"]["labels"][
-                        self.config["task"]["label_index"]
-                    ],
-                    self.config["task"]["metric"],
-                )
-            ] = errors[0]
-        else:
-            for i, label in enumerate(self.config["task"]["labels"]):
-                metrics[
-                    "{}/{}".format(label, self.config["task"]["metric"])
-                ] = errors[i]
-
-        if "grad_input" in self.config["task"]:
-            force_pred = force_output
-            force_target = batch.force
-
-            if self.config["task"].get("eval_on_free_atoms", True):
-                mask = batch.fixed == 0
-                force_pred = force_pred[mask]
-                force_target = force_target[mask]
-
-            if self.config["dataset"].get("normalize_labels", True):
-                grad_input_errors = eval(self.config["task"]["metric"])(
-                    self.normalizers["grad_target"].denorm(force_pred).cpu(),
-                    force_target.cpu(),
-                )
-            else:
-                grad_input_errors = eval(self.config["task"]["metric"])(
-                    force_pred.cpu(), force_target.cpu()
-                )
-            metrics[
-                "force_x/{}".format(self.config["task"]["metric"])
-            ] = grad_input_errors[0]
-            metrics[
-                "force_y/{}".format(self.config["task"]["metric"])
-            ] = grad_input_errors[1]
-            metrics[
-                "force_z/{}".format(self.config["task"]["metric"])
-            ] = grad_input_errors[2]
-
-        return out, metrics
-
-    def _compute_loss(self, out, batch):
-        loss = []
-
-        if self.config["dataset"].get("normalize_labels", True):
-            target_normed = self.normalizers["target"].norm(batch.y)
-        else:
-            target_normed = batch.y
-
-        loss.append(self.criterion(out["output"], target_normed))
-
-        # TODO(abhshkdz): Test support for gradients wrt input.
-        # TODO(abhshkdz): Make this general; remove dependence on `.forces`.
-        if "grad_input" in self.config["task"]:
-            if self.config["dataset"].get("normalize_labels", True):
-                grad_target_normed = self.normalizers["grad_target"].norm(
-                    batch.force
-                )
-            else:
-                grad_target_normed = batch.force
-
-            # Force coefficient = 30 has been working well for us.
-            force_mult = self.config["optim"].get("force_coefficient", 30)
-            if self.config["task"].get("train_on_free_atoms", False):
-                mask = batch.fixed == 0
-                loss.append(
-                    force_mult
-                    * self.criterion(
-                        out["force_output"][mask], grad_target_normed[mask]
-                    )
-                )
-            else:
-                loss.append(
-                    force_mult
-                    * self.criterion(out["force_output"], grad_target_normed)
-                )
-
-        # Sanity check to make sure the compute graph is correct.
-        for lc in loss:
-            assert hasattr(lc, "grad_fn")
-
-        loss = sum(loss)
-        return loss
+    @abstractmethod
+    def _compute_loss(self, out, batch_list):
+        """ Derived classes should implement this function."""
 
     def _backward(self, loss):
         self.optimizer.zero_grad()

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -405,9 +405,6 @@ class BaseTrainer:
 
     def load_extras(self):
         self.scheduler = LRScheduler(self.optimizer, self.config["optim"])
-        self.update_lr_on_step = self.config["optim"].get(
-            "update_lr_on_step", False
-        )
         # metrics.
         self.meter = Meter(split="train")
 

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -308,7 +308,7 @@ class BaseTrainer(ABC):
             self.model.load_state_dict(checkpoint["state_dict"])
 
         self.optimizer.load_state_dict(checkpoint["optimizer"])
-        if "scheduler" in checkpoint:
+        if "scheduler" in checkpoint and checkpoint["scheduler"] is not None:
             self.scheduler.scheduler.load_state_dict(checkpoint["scheduler"])
 
         for key in checkpoint["normalizers"]:

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -308,7 +308,7 @@ class BaseTrainer(ABC):
             self.model.load_state_dict(checkpoint["state_dict"])
 
         self.optimizer.load_state_dict(checkpoint["optimizer"])
-        if checkpoint["scheduler"]:
+        if "scheduler" in checkpoint:
             self.scheduler.scheduler.load_state_dict(checkpoint["scheduler"])
 
         for key in checkpoint["normalizers"]:

--- a/ocpmodels/trainers/energy_trainer.py
+++ b/ocpmodels/trainers/energy_trainer.py
@@ -305,13 +305,11 @@ class EnergyTrainer(BaseTrainer):
                     else:
                         self.save(current_epoch, current_step, self.metrics)
 
-                if (
-                    self.scheduler.scheduler_type == "ReduceLROnPlateau"
-                    and current_step % eval_every == 0
-                ):
-                    self.scheduler.step(
-                        metrics=val_metrics[primary_metric]["metric"],
-                    )
+                if self.scheduler.scheduler_type == "ReduceLROnPlateau":
+                    if current_step % eval_every == 0:
+                        self.scheduler.step(
+                            metrics=val_metrics[primary_metric]["metric"],
+                        )
                 else:
                     self.scheduler.step()
 

--- a/ocpmodels/trainers/energy_trainer.py
+++ b/ocpmodels/trainers/energy_trainer.py
@@ -267,14 +267,17 @@ class EnergyTrainer(BaseTrainer):
                         split="train",
                     )
 
-                if self.update_lr_on_step:
+                if self.scheduler.update_lr_on_step:
                     self.scheduler.step()
+
+            if self.scheduler.update_lr_on_epoch:
+                self.scheduler.step()
 
             torch.cuda.empty_cache()
 
             if self.val_loader is not None:
                 val_metrics = self.validate(split="val", epoch=epoch)
-                if not self.update_lr_on_step:
+                if self.scheduler.update_lr_on_val:
                     self.scheduler.step(val_metrics[primary_metric]["metric"])
                 if (
                     val_metrics[self.evaluator.task_primary_metric[self.name]][
@@ -294,8 +297,6 @@ class EnergyTrainer(BaseTrainer):
                             disable_tqdm=False,
                         )
             else:
-                if not self.update_lr_on_step:
-                    self.scheduler.step()
                 current_step = (epoch + 1) * len(self.train_loader)
                 self.save(epoch + 1, current_step, self.metrics)
 

--- a/ocpmodels/trainers/energy_trainer.py
+++ b/ocpmodels/trainers/energy_trainer.py
@@ -225,7 +225,6 @@ class EnergyTrainer(BaseTrainer):
         start_epoch = self.start_step // len(self.train_loader)
         for epoch in range(start_epoch, self.config["optim"]["max_epochs"]):
             self.train_sampler.set_epoch(epoch)
-            self.model.train()
 
             skip_steps = 0
             if epoch == start_epoch and start_epoch > 0:
@@ -233,6 +232,7 @@ class EnergyTrainer(BaseTrainer):
             train_loader_iter = iter(self.train_loader)
 
             for i in range(skip_steps, len(self.train_loader)):
+                self.model.train()
                 current_epoch = epoch + (i + 1) / len(self.train_loader)
                 current_step = epoch * len(self.train_loader) + (i + 1)
 

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -446,13 +446,11 @@ class ForcesTrainer(BaseTrainer):
                     else:
                         self.save(current_epoch, current_step, self.metrics)
 
-                if (
-                    self.scheduler.scheduler_type == "ReduceLROnPlateau"
-                    and iters % eval_every == 0
-                ):
-                    self.scheduler.step(
-                        metrics=val_metrics[primary_metric]["metric"],
-                    )
+                if self.scheduler.scheduler_type == "ReduceLROnPlateau":
+                    if iters % eval_every == 0:
+                        self.scheduler.step(
+                            metrics=val_metrics[primary_metric]["metric"],
+                        )
                 else:
                     self.scheduler.step()
 

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -361,14 +361,13 @@ class ForcesTrainer(BaseTrainer):
 
         start_epoch = self.start_step // len(self.train_loader)
         for epoch in range(start_epoch, self.config["optim"]["max_epochs"]):
-            self.model.train()
-
             skip_steps = 0
             if epoch == start_epoch and start_epoch > 0:
                 skip_steps = start_epoch % len(self.train_loader)
             train_loader_iter = iter(self.train_loader)
 
             for i in range(skip_steps, len(self.train_loader)):
+                self.model.train()
                 current_epoch = epoch + (i + 1) / len(self.train_loader)
                 current_step = epoch * len(self.train_loader) + (i + 1)
 

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -345,7 +345,9 @@ class ForcesTrainer(BaseTrainer):
         return predictions
 
     def train(self):
-        eval_every = self.config["optim"].get("eval_every", -1)
+        eval_every = self.config["optim"].get(
+            "eval_every", len(self.train_loader)
+        )
         primary_metric = self.config["task"].get(
             "primary_metric", self.evaluator.task_primary_metric[self.name]
         )
@@ -363,7 +365,12 @@ class ForcesTrainer(BaseTrainer):
             train_loader_iter = iter(self.train_loader)
 
             for i in range(skip_steps, len(self.train_loader)):
+                current_epoch = epoch + (i + 1) / len(self.train_loader)
+                current_step = epoch * len(self.train_loader) + (i + 1)
+
+                # Get a batch.
                 batch = next(train_loader_iter)
+
                 # Forward, loss, backward.
                 with torch.cuda.amp.autocast(enabled=self.scaler is not None):
                     out = self._forward(batch)
@@ -371,6 +378,7 @@ class ForcesTrainer(BaseTrainer):
                 loss = self.scaler.scale(loss) if self.scaler else loss
                 self._backward(loss)
                 scale = self.scaler.get_scale() if self.scaler else 1.0
+
                 # Compute metrics.
                 self.metrics = self._compute_metrics(
                     out,
@@ -382,48 +390,41 @@ class ForcesTrainer(BaseTrainer):
                     "loss", loss.item() / scale, self.metrics
                 )
 
-                # Print metrics, make plots.
+                # Log metrics.
                 log_dict = {k: self.metrics[k]["metric"] for k in self.metrics}
                 log_dict.update(
-                    {"epoch": epoch + (i + 1) / len(self.train_loader)}
+                    {
+                        "lr": self.scheduler.get_lr(),
+                        "epoch": current_epoch,
+                        "step": current_step,
+                    }
                 )
                 if (
-                    i % self.config["cmd"]["print_every"] == 0
+                    current_step % self.config["cmd"]["print_every"] == 0
                     and distutils.is_master()
                 ):
                     log_str = [
-                        "{}: {:.4f}".format(k, v) for k, v in log_dict.items()
+                        "{}: {:.2e}".format(k, v) for k, v in log_dict.items()
                     ]
                     print(", ".join(log_str))
-                    print(
-                        "### LR ###: {lr} ### epoch ### {e}".format(
-                            lr=self.optimizer.param_groups[0]["lr"],
-                            e=epoch + (i + 1) / len(self.train_loader),
-                        )
-                    )
                     self.metrics = {}
 
-                log_dict.update({"lr": self.scheduler.get_lr()})
                 if self.logger is not None:
                     self.logger.log(
                         log_dict,
-                        step=epoch * len(self.train_loader) + i + 1,
+                        step=current_step,
                         split="train",
                     )
 
                 iters += 1
 
                 # Evaluate on val set every `eval_every` iterations.
-                if eval_every != -1 and iters % eval_every == 0:
+                if iters % eval_every == 0:
                     if self.val_loader is not None:
                         val_metrics = self.validate(
                             split="val",
                             epoch=epoch - 1 + (i + 1) / len(self.train_loader),
                         )
-                        if self.scheduler.update_lr_on_val:
-                            self.scheduler.step(
-                                val_metrics[primary_metric]["metric"]
-                            )
                         if (
                             "mae" in primary_metric
                             and val_metrics[primary_metric]["metric"]
@@ -435,12 +436,6 @@ class ForcesTrainer(BaseTrainer):
                             self.best_val_metric = val_metrics[primary_metric][
                                 "metric"
                             ]
-                            current_epoch = epoch + (i + 1) / len(
-                                self.train_loader
-                            )
-                            current_step = epoch * len(self.train_loader) + (
-                                i + 1
-                            )
                             self.save(current_epoch, current_step, val_metrics)
                             if self.test_loader is not None:
                                 self.predict(
@@ -448,44 +443,17 @@ class ForcesTrainer(BaseTrainer):
                                     results_file="predictions",
                                     disable_tqdm=False,
                                 )
+                    else:
+                        self.save(current_epoch, current_step, self.metrics)
 
-                if self.scheduler.update_lr_on_step:
+                try:
+                    self.scheduler.step(
+                        metrics=val_metrics[primary_metric]["metric"],
+                    )
+                except NameError:
                     self.scheduler.step()
 
-            if self.scheduler.update_lr_on_epoch:
-                self.scheduler.step()
-
             torch.cuda.empty_cache()
-
-            if eval_every == -1:
-                if self.val_loader is not None:
-                    val_metrics = self.validate(split="val", epoch=epoch)
-                    if self.scheduler.update_lr_on_val:
-                        self.scheduler.step(
-                            val_metrics[primary_metric]["metric"]
-                        )
-                    if (
-                        "mae" in primary_metric
-                        and val_metrics[primary_metric]["metric"]
-                        < self.best_val_metric
-                    ) or (
-                        val_metrics[primary_metric]["metric"]
-                        > self.best_val_metric
-                    ):
-                        self.best_val_metric = val_metrics[primary_metric][
-                            "metric"
-                        ]
-                        current_step = (epoch + 1) * len(self.train_loader)
-                        self.save(epoch + 1, current_step, val_metrics)
-                        if self.test_loader is not None:
-                            self.predict(
-                                self.test_loader,
-                                results_file="predictions",
-                                disable_tqdm=False,
-                            )
-                else:
-                    current_step = (epoch + 1) * len(self.train_loader)
-                    self.save(epoch + 1, current_step, self.metrics)
 
         self.train_dataset.close_db()
         if "val_dataset" in self.config:

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -446,11 +446,14 @@ class ForcesTrainer(BaseTrainer):
                     else:
                         self.save(current_epoch, current_step, self.metrics)
 
-                try:
+                if (
+                    self.scheduler.scheduler_type == "ReduceLROnPlateau"
+                    and iters % eval_every == 0
+                ):
                     self.scheduler.step(
                         metrics=val_metrics[primary_metric]["metric"],
                     )
-                except NameError:
+                else:
                     self.scheduler.step()
 
             torch.cuda.empty_cache()


### PR DESCRIPTION
Currently, there is some unexpected behavior (not necessarily a bug) when the learning rate scheduler takes a step in the force trainer [here](https://github.com/Open-Catalyst-Project/ocp/blob/178984b9044ac619506c2d99bd03ee9bb3a87d95/ocpmodels/trainers/forces_trainer.py#L417-L420). The unexpected behavior only occurs if step on epoch is expected and `eval_every` is set. 

For example the s2ef 200k forcenet config would not run as expected because `eval_every` is set causing the scheduler to step every `eval_every` steps instead of every epoch.    

This PR makes the scheduler step type explicit being either update_lr_on_step, update_lr_on_epoch, or update_lr_on_val. The default being update_lr_on_epoch. Allowing the `eval_every` flag to be used with any lr step type.

Here is an example of the unexpected behavior for the s2ef 200k schnet config ([schnet.yml](https://github.com/Open-Catalyst-Project/ocp/blob/master/configs/s2ef/200k/schnet/schnet.yml)):
without `eval_every` the learning rate schedule result is as expected in the config

```
### LR ###: 0.0001 ### epoch ### 0.003194888178913738
### LR ###: 0.00023333333333333333 ### epoch ### 1.0031948881789137
### LR ###: 0.00036666666666666667 ### epoch ### 2.0031948881789137
### LR ###: 0.0005 ### epoch ### 3.0031948881789137
### LR ###: 5e-05 ### epoch ### 5.003194888178914
### LR ###: 5.000000000000001e-06 ### epoch ### 8.003194888178914
### LR ###: 5.000000000000001e-07 ### epoch ### 10.003194888178914
```
with `eval_every` set to a number of steps < total steps in an epoch, the result is that the lr schedule advances much quicker than expected

```
### LR ###: 0.0001 ### epoch ### 0.003194888178913738
### LR ###: 0.00023333333333333333 ### epoch ### 0.6421725239616614
### LR ###: 0.00036666666666666667 ### epoch ### 0.9616613418530351
### LR ###: 0.0005 ### epoch ### 1.6421725239616614
### LR ###: 5e-05 ### epoch ### 2.642172523961661
### LR ###: 5.000000000000001e-06 ### epoch ### 3.961661341853035
### LR ###: 5.000000000000001e-07 ### epoch ### 4.961661341853035
```

There might be better/more elegant ways to solve this issue, but wanted to bring it to everyones attention.
