### PR TITLE
Scheduler bugfix

### DIFF
--- a/ocpmodels/modules/scheduler.py
+++ b/ocpmodels/modules/scheduler.py
@@ -1,6 +1,7 @@
 import inspect
 
 import torch.optim.lr_scheduler as lr_scheduler
+
 from ocpmodels.common.utils import warmup_lr_lambda
 
 
@@ -54,6 +55,7 @@ class LRScheduler:
             for param in sig.parameters.values()
             if param.kind == param.POSITIONAL_OR_KEYWORD
         ]
+        filter_keys.remove("optimizer")
         scheduler_args = {
             arg: self.config[arg] for arg in self.config if arg in filter_keys
         }


### PR DESCRIPTION
Resolves a bug when an alternative optimizer is defined in the config:
```
  File "/home/jovyan/projects/ocp/ocpmodels/modules/scheduler.py", line 35, in __init__
    self.scheduler = self.scheduler(optimizer, **scheduler_args)
TypeError: __init__() got multiple values for argument 'optimizer'
```
Example config - 
```
optim:
  batch_size: 32
  eval_batch_size: 16
  num_workers: 64
  optimizer: Adam
  optimizer_params: {"amsgrad": True}
  lr_initial: 0.0005
  scheduler: ReduceLROnPlateau
  mode: min
  factor: 0.8
  patience: 10
  max_epochs: 30
  force_coefficient: 100
```