### PR TITLE
Adds checkpointing functionality for Ray Tune

### DIFF
--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -387,29 +387,28 @@ class BaseTrainer(ABC):
     def hpo_update(
         self, epoch, step, train_metrics, val_metrics, test_metrics=None
     ):
-        if self.is_hpo:
-            progress = {
-                "steps": step,
-                "epochs": epoch,
-                "act_lr": self.optimizer.param_groups[0]["lr"],
-            }
-            # checkpointing must occur before reporter
-            # default is no checkpointing
-            self.save_hpo(
-                epoch,
-                step,
-                val_metrics,
-                self.hpo_checkpoint_every,
-            )
-            # report metrics to tune
-            tune_reporter(
-                iters=progress,
-                train_metrics={
-                    k: train_metrics[k]["metric"] for k in self.metrics
-                },
-                val_metrics={k: val_metrics[k]["metric"] for k in val_metrics},
-                test_metrics=test_metrics,
-            )
+        progress = {
+            "steps": step,
+            "epochs": epoch,
+            "act_lr": self.optimizer.param_groups[0]["lr"],
+        }
+        # checkpointing must occur before reporter
+        # default is no checkpointing
+        self.save_hpo(
+            epoch,
+            step,
+            val_metrics,
+            self.hpo_checkpoint_every,
+        )
+        # report metrics to tune
+        tune_reporter(
+            iters=progress,
+            train_metrics={
+                k: train_metrics[k]["metric"] for k in self.metrics
+            },
+            val_metrics={k: val_metrics[k]["metric"] for k in val_metrics},
+            test_metrics=test_metrics,
+        )
 
     @abstractmethod
     def train(self):

--- a/ocpmodels/trainers/energy_trainer.py
+++ b/ocpmodels/trainers/energy_trainer.py
@@ -308,12 +308,13 @@ class EnergyTrainer(BaseTrainer):
                                     disable_tqdm=False,
                                 )
 
-                        self.hpo_update(
-                            current_epoch,
-                            current_step,
-                            self.metrics,
-                            val_metrics,
-                        )
+                        if self.is_hpo:
+                            self.hpo_update(
+                                current_epoch,
+                                current_step,
+                                self.metrics,
+                                val_metrics,
+                            )
 
                     else:
                         self.save(current_epoch, current_step, self.metrics)

--- a/ocpmodels/trainers/energy_trainer.py
+++ b/ocpmodels/trainers/energy_trainer.py
@@ -305,7 +305,14 @@ class EnergyTrainer(BaseTrainer):
                         "epochs": epoch + 1,
                         "act_lr": self.optimizer.param_groups[0]["lr"],
                     }
-                    # checkpointing must be before reporter
+                    # checkpointing must occur before reporter
+                    # default is no checkpointing
+                    self.save_hpo(
+                        epoch + 1,
+                        current_step,
+                        val_metrics,
+                        self.hpo_checkpoint_every,
+                    )
                     # report metrics to tune
                     tune_reporter(
                         iters=progress,

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -18,7 +18,7 @@ from ocpmodels.common import distutils
 from ocpmodels.common.data_parallel import ParallelCollater
 from ocpmodels.common.registry import registry
 from ocpmodels.common.relaxation.ml_relaxation import ml_relax
-from ocpmodels.common.utils import plot_histogram, tune_reporter
+from ocpmodels.common.utils import plot_histogram
 from ocpmodels.modules.evaluator import Evaluator
 from ocpmodels.modules.normalizer import Normalizer
 from ocpmodels.trainers.base_trainer import BaseTrainer
@@ -448,33 +448,13 @@ class ForcesTrainer(BaseTrainer):
                                     disable_tqdm=False,
                                 )
 
-                        if self.is_hpo:
-                            progress = {
-                                "steps": current_step,
-                                "epochs": current_epoch,
-                                "act_lr": self.optimizer.param_groups[0]["lr"],
-                            }
-                            # checkpointing must occur before reporter
-                            # default is no checkpointing
-                            self.save_hpo(
-                                current_epoch,
-                                current_step,
-                                val_metrics,
-                                self.hpo_checkpoint_every,
-                            )
-                            # report metrics to tune
-                            tune_reporter(
-                                iters=progress,
-                                train_metrics={
-                                    k: self.metrics[k]["metric"]
-                                    for k in self.metrics
-                                },
-                                val_metrics={
-                                    k: val_metrics[k]["metric"]
-                                    for k in val_metrics
-                                },
-                                test_metrics=None,
-                            )
+                        self.hpo_update(
+                            current_epoch,
+                            current_step,
+                            self.metrics,
+                            val_metrics,
+                        )
+
                     else:
                         self.save(current_epoch, current_step, self.metrics)
 

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -451,7 +451,14 @@ class ForcesTrainer(BaseTrainer):
                                 "epochs": current_epoch,
                                 "act_lr": self.optimizer.param_groups[0]["lr"],
                             }
-                            # checkpointing must be before reporter
+                            # checkpointing must occur before reporter
+                            # default is no checkpointing
+                            self.save_hpo(
+                                current_epoch,
+                                current_step,
+                                val_metrics,
+                                self.hpo_checkpoint_every,
+                            )
                             # report metrics to tune
                             tune_reporter(
                                 iters=progress,

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -448,12 +448,13 @@ class ForcesTrainer(BaseTrainer):
                                     disable_tqdm=False,
                                 )
 
-                        self.hpo_update(
-                            current_epoch,
-                            current_step,
-                            self.metrics,
-                            val_metrics,
-                        )
+                        if self.is_hpo:
+                            self.hpo_update(
+                                current_epoch,
+                                current_step,
+                                self.metrics,
+                                val_metrics,
+                            )
 
                     else:
                         self.save(current_epoch, current_step, self.metrics)

--- a/scripts/hpo/README.md
+++ b/scripts/hpo/README.md
@@ -10,13 +10,16 @@ is_hpo: True
 
 optim:
   …
-  eval_every: TDB
+  eval_every: (int) number of steps
+  checkpoint_every: (int: optional) number of steps
 ```
 The first two are easily set. The logger is set to None because Ray Tune internally handles the logging.
 
 The `eval_every` setting is case specific and will likely require some experimentation. The `eval_every` flag sets how often the validation set is run in number of steps. Depending on the OCP model and dataset of interest, training for a single epoch can take a substantial amount of time. However, to take full advantage of HPO methods that minimize compute by terminating trials that are not promising, such as successive halving, communication of train and val metrics need to happen on shorter timescales. Paraphrasing the Ray Tune docs, `eval_every` should be set large enough to avoid overheads but short enough to report progress periodically — minutes timescale recommended.
 
 The `eval_every` setting is only available for the force trainer so when using the energy trainer validation will be run and reporting to Ray Tune will occur on a per epoch basis.
+
+The `checkpoint_every` setting determines how frequently, in steps, Ray Tune will write a checkpoint. Checkpointing can create a lot of overhead for certain HPO methods so do not do it too frequently. The default behavior is no checkpointing.
 
 ## Usage with Slurm
 
@@ -36,6 +39,11 @@ Slurm scripts taken from https://github.com/NERSC/slurm-ray-cluster
 
 For usage with other cluster managers or cloud resources please refer to the
 [Distributed Ray Docs](https://docs.ray.io/en/master/cluster/index.html#)
+
+## Examples
+
+1. Asynchronous Successive Halving — `ocp/scripts/hpo/run_tune.py`
+2. Population Based Training — `ocp/scripts/hpo/run_tune_pbt.py`
 
 ## Testing/Debugging Ray Tune
 

--- a/scripts/hpo/run_tune_pbt.py
+++ b/scripts/hpo/run_tune_pbt.py
@@ -3,7 +3,7 @@ import os
 import ray
 from ray import tune
 from ray.tune import CLIReporter
-from ray.tune.schedulers import ASHAScheduler
+from ray.tune.schedulers import PopulationBasedTraining
 
 from ocpmodels.common.flags import flags
 from ocpmodels.common.registry import registry
@@ -13,6 +13,8 @@ from ocpmodels.common.utils import build_config, setup_imports
 # this function is general and should work for any ocp trainer
 def ocp_trainable(config, checkpoint_dir=None):
     setup_imports()
+    # update config for PBT learning rate
+    config["optim"].update(lr_initial=config["lr"])
     # trainer defaults are changed to run HPO
     trainer = registry.get_trainer_class(config.get("trainer", "simple"))(
         task=config["task"],
@@ -35,39 +37,32 @@ def ocp_trainable(config, checkpoint_dir=None):
     if checkpoint_dir:
         checkpoint = os.path.join(checkpoint_dir, "checkpoint")
         trainer.load_pretrained(checkpoint)
+    # set learning rate
+    for g in trainer.optimizer.param_groups:
+        g["lr"] = config["lr"]
     # start training
     trainer.train()
 
 
-# this section defines the hyperparameters to tune and all the Ray Tune settings
-# current params/settings are an example for ForceNet
+# this section defines all the Ray Tune run parameters
 def main():
     # parse config
     parser = flags.get_parser()
     args, override_args = parser.parse_known_args()
     config = build_config(args, override_args)
     # add parameters to tune using grid or random search
-    config["model"].update(
-        hidden_channels=tune.choice([256, 384, 512, 640, 704]),
-        decoder_hidden_channels=tune.choice([256, 384, 512, 640, 704]),
-        depth_mlp_edge=tune.choice([1, 2, 3, 4, 5]),
-        depth_mlp_node=tune.choice([1, 2, 3, 4, 5]),
-        num_interactions=tune.choice([3, 4, 5, 6]),
-    )
+    config["lr"] = tune.loguniform(0.0001, 0.01)
     # define scheduler
-    scheduler = ASHAScheduler(
-        time_attr="steps",
+    scheduler = PopulationBasedTraining(
+        time_attr="training_iteration",
         metric="val_loss",
         mode="min",
-        max_t=100000,
-        grace_period=2000,
-        reduction_factor=4,
-        brackets=1,
+        perturbation_interval=1,
+        hyperparam_mutations={
+            "lr": tune.loguniform(0.000001, 0.01),
+        },
     )
     # ray init
-    # for debug
-    # ray.init(local_mode=True)
-    # for slurm cluster
     ray.init(
         address="auto",
         _node_ip_address=os.environ["ip_head"].split(":")[0],
@@ -79,6 +74,7 @@ def main():
         metric="val_loss",
         mode="min",
         metric_columns={
+            "act_lr": "act_lr",
             "steps": "steps",
             "epochs": "epochs",
             "training_iteration": "training_iteration",
@@ -86,15 +82,16 @@ def main():
             "val_forces_mae": "val_forces_mae",
         },
     )
-
     # define run parameters
     analysis = tune.run(
         ocp_trainable,
         resources_per_trial={"cpu": 8, "gpu": 1},
         config=config,
+        stop={"epochs": 2},
+        # time_budget_s=28200,
         fail_fast=False,
         local_dir=config.get("run_dir", "./"),
-        num_samples=500,
+        num_samples=8,
         progress_reporter=reporter,
         scheduler=scheduler,
     )

--- a/scripts/hpo/run_tune_pbt.py
+++ b/scripts/hpo/run_tune_pbt.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import ray
@@ -87,7 +88,7 @@ def main():
         ocp_trainable,
         resources_per_trial={"cpu": 8, "gpu": 1},
         config=config,
-        stop={"epochs": 2},
+        stop={"epochs": 12},
         # time_budget_s=28200,
         fail_fast=False,
         local_dir=config.get("run_dir", "./"),


### PR DESCRIPTION
This is part three of #232.

Adds the ability to checkpoint with Ray Tune, enabling methods such as population based training. The hpo documentation was updated accordingly.

Notes:

- I added a [save_state](https://github.com/Open-Catalyst-Project/ocp/blob/hpo_checkpointing/ocpmodels/trainers/base_trainer.py#L424) function to the base trainer to minimize duplicate code between the `save` and `save_hpo` functions 

- I added a [variable](https://github.com/Open-Catalyst-Project/ocp/blob/hpo_checkpointing/ocpmodels/trainers/base_trainer.py#L150) in the optim section of the config `checkpoint_every`. This allows for control of the HPO checkpointing frequency instead of just on or off. For the moment, I put the variable in the optim section, but could create an HPO section — seemed unnecessary for one variable. This feels a bit hacky so open to better suggestions.

Features:

- adds hpo checkpointing enabling population based training
- ability to control frequency of hpo checkpointing