### PR TITLE
Adds additional slurm parameters for submitit

### DIFF
--- a/main.py
+++ b/main.py
@@ -112,6 +112,9 @@ if __name__ == "__main__":
     config = build_config(args, override_args)
 
     if args.submit:  # Run on cluster
+        slurm_add_params = config.get(
+            "slurm", None
+        )  # additional slurm arguments
         if args.sweep_yml:  # Run grid search
             configs = create_grid(config, args.sweep_yml)
         else:
@@ -130,6 +133,7 @@ if __name__ == "__main__":
             cpus_per_task=(args.num_workers + 1),
             tasks_per_node=(args.num_gpus if args.distributed else 1),
             nodes=args.num_nodes,
+            slurm_additional_parameters=slurm_add_params,
         )
         jobs = executor.map_array(Runner(), configs)
         print("Submitted jobs:", ", ".join([job.job_id for job in jobs]))


### PR DESCRIPTION
In order to use submitit with OCP at NERSC additional slurm parameters are required. For example adding a `constraint` or adding an `account`.

This PR allows for additional slurm arguments through a slurm section of the yaml config. I thought it would be better in the config than adding a bunch of command line arguments. Below is an example slurm section:

```
slurm:
  account: n1111
  qos: special
  partition: null
  constraint: gpu
  time: 10
``` 

Features:

- Ability to add or overwrite submitit slurm parameters with `slurm_additional_parameters` dict 