### PR TITLE
Pytorch 1.8.1, Python 3.8 Support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 20.8b1
     hooks:
     - id: black
-      language_version: python3.6
+      language_version: python3.8
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:

--- a/env.common.yml
+++ b/env.common.yml
@@ -9,8 +9,8 @@ dependencies:
   - pip
   - pre-commit=2.10.*
   - pymatgen=2020.12.31
-  - python=3.6.*
-  - pytorch=1.7.1
+  - python=3.8.*
+  - pytorch=1.8.1
   - pyyaml=5.4.*
   - tensorboard=2.4.*
   - tqdm=4.58.*
@@ -22,7 +22,7 @@ dependencies:
     - demjson
     - Pillow
     - ray[tune]==1.1.0
-    - torch-geometric==1.6.3
+    - torch-geometric==1.7.0
     - wandb
     - lmdb==1.1.1
     - pytest==6.2.2

--- a/env.common.yml
+++ b/env.common.yml
@@ -22,7 +22,7 @@ dependencies:
     - demjson
     - Pillow
     - ray[tune]==1.1.0
-    - torch-geometric==1.7.0
+    - git+https://github.com/rusty1s/pytorch_geometric.git@4ea63d3
     - wandb
     - lmdb==1.1.1
     - pytest==6.2.2

--- a/env.cpu.yml
+++ b/env.cpu.yml
@@ -1,7 +1,7 @@
 dependencies:
   - cpuonly
   - pip:
-    - -f https://pytorch-geometric.com/whl/torch-1.7.0+cpu.html
+    - -f https://pytorch-geometric.com/whl/torch-1.8.0+cpu.html
     - torch-cluster
     - torch-scatter
     - torch-sparse

--- a/env.gpu.yml
+++ b/env.gpu.yml
@@ -3,9 +3,9 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - cudatoolkit=11.0
+  - cudatoolkit=10.2
   - pip:
-    - -f https://pytorch-geometric.com/whl/torch-1.7.0+cu110.html
+    - -f https://pytorch-geometric.com/whl/torch-1.8.0+cu102.html
     - torch-cluster
     - torch-scatter
     - torch-sparse

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -79,7 +79,7 @@ class BaseTrainer(ABC):
         )
         # create directories from master rank only
         distutils.broadcast(timestamp, 0)
-        timestamp = datetime.datetime.fromtimestamp(timestamp).strftime(
+        timestamp = datetime.datetime.fromtimestamp(timestamp.int()).strftime(
             "%Y-%m-%d-%H-%M-%S"
         )
         if identifier:


### PR DESCRIPTION
Updates repo and corresponding dependencies for Pytorch 1.8, Python 3.8.

~~SchNet on this version of torch_geometric currently breaks, I have raised the issue in their repo https://github.com/rusty1s/pytorch_geometric/issues/2708. @abhshkdz if you think of a work around let me know, we'll have to wait for that before we merge this.~~ They've pushed a fixed.

Note - I've dropped the CUDA version to 10.2, torch_geometric and pytorch have binaries for 10.2 and 11.1, not 11.0.