### PR TITLE
#GPUs>#LMDBs bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ Check that you can invoke `conda-merge` by running `conda-merge -h`.
 
 ### GPU machines
 
-Instructions are for PyTorch 1.7.1, CUDA 11.0 specifically.
+Instructions are for PyTorch 1.8.1, CUDA 10.2 specifically.
 
 First, check that CUDA is in your `PATH` and `LD_LIBRARY_PATH`, e.g.
 ```bash
 $ echo $PATH | tr ':' '\n' | grep cuda
-/public/apps/cuda/11.0/bin
+/public/apps/cuda/10.2/bin
 
 $ echo $LD_LIBRARY_PATH | tr ':' '\n' | grep cuda
-/public/apps/cuda/11.0/lib64
+/public/apps/cuda/10.2/lib64
 ```
 
 The exact paths may differ on your system.

--- a/ocpmodels/datasets/trajectory_lmdb.py
+++ b/ocpmodels/datasets/trajectory_lmdb.py
@@ -37,58 +37,22 @@ class TrajectoryLmdbDataset(Dataset):
         super(TrajectoryLmdbDataset, self).__init__()
         self.config = config
 
-        world_size = distutils.get_world_size()
-        rank = distutils.get_rank()
-
-        # Set seed.
-        seed = (torch.initial_seed() + rank) % 2 ** 32
-        np.random.seed(seed)
-        torch.manual_seed(seed)
-        random.seed(seed)
-
         srcdir = Path(self.config["src"])
         db_paths = sorted(srcdir.glob("*.lmdb"))
         assert len(db_paths) > 0, f"No LMDBs found in {srcdir}"
 
-        # Read all LMDBs to set the size of each dataloader replica.
-        lengths = []
-        for db_path in db_paths:
-            env = self.connect_db(db_path)
-            lengths.append(
-                pickle.loads(env.begin().get("length".encode("ascii")))
-            )
-            env.close()
-        replica_size = math.ceil(sum(lengths) / world_size)
-
-        # Each process only reads a subset of each DB file.
         self._keys, self.envs = [], []
         for db_path in db_paths:
             self.envs.append(self.connect_db(db_path))
             length = pickle.loads(
                 self.envs[-1].begin().get("length".encode("ascii"))
             )
-            # Each LMDB must contain at least world_size data points
-            assert (
-                length / world_size >= 1
-            ), f"Each LMDB must be at least length {world_size}"
-            length -= length % world_size
-            self._keys.append(list(range(rank, length, world_size)))
+            self._keys.append(list(range(length)))
 
         keylens = [len(k) for k in self._keys]
-        # Need to pad dataloaders so all have the same no. of samples.
-        # This means that dataloaders will have some repeated samples
-        # that need to be pruned out in post-processing.
-        if sum(keylens) < replica_size:
-            self._keys[-1].extend(
-                [self._keys[-1][-1]] * (replica_size - sum(keylens))
-            )
-            keylens = [len(k) for k in self._keys]
-
         self._keylen_cumulative = np.cumsum(keylens).tolist()
         self.transform = transform
         self.num_samples = sum(keylens)
-
-        assert self.num_samples == replica_size
 
     def __len__(self):
         return self.num_samples

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -366,6 +366,7 @@ class ForcesTrainer(BaseTrainer):
 
         start_epoch = self.start_step // len(self.train_loader)
         for epoch in range(start_epoch, self.config["optim"]["max_epochs"]):
+            self.train_sampler.set_epoch(epoch)
             skip_steps = 0
             if epoch == start_epoch and start_epoch > 0:
                 skip_steps = start_epoch % len(self.train_loader)

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -111,77 +111,82 @@ class ForcesTrainer(BaseTrainer):
                 self.config["task"]["dataset"]
             )(self.config["dataset"])
 
+            self.train_sampler = DistributedSampler(
+                self.train_dataset,
+                num_replicas=distutils.get_world_size(),
+                rank=distutils.get_rank(),
+                shuffle=True,
+            )
+
             self.train_loader = DataLoader(
                 self.train_dataset,
                 batch_size=self.config["optim"]["batch_size"],
-                shuffle=True,
                 collate_fn=self.parallel_collater,
                 num_workers=self.config["optim"]["num_workers"],
                 pin_memory=True,
+                sampler=self.train_sampler,
             )
 
             self.val_loader = self.test_loader = None
+            self.val_sampler = self.test_sampler = None
 
             if "val_dataset" in self.config:
                 self.val_dataset = registry.get_dataset_class(
                     self.config["task"]["dataset"]
                 )(self.config["val_dataset"])
+                self.val_sampler = DistributedSampler(
+                    self.val_dataset,
+                    num_replicas=distutils.get_world_size(),
+                    rank=distutils.get_rank(),
+                    shuffle=False,
+                )
                 self.val_loader = DataLoader(
                     self.val_dataset,
                     self.config["optim"].get("eval_batch_size", 64),
-                    shuffle=False,
                     collate_fn=self.parallel_collater,
                     num_workers=self.config["optim"]["num_workers"],
                     pin_memory=True,
+                    sampler=self.val_sampler,
                 )
             if "test_dataset" in self.config:
                 self.test_dataset = registry.get_dataset_class(
                     self.config["task"]["dataset"]
                 )(self.config["test_dataset"])
-                self.test_loader = DataLoader(
+                self.test_sampler = DistributedSampler(
                     self.test_dataset,
-                    self.config["optim"].get("eval_batch_size", 64),
-                    shuffle=False,
-                    collate_fn=self.parallel_collater,
-                    num_workers=self.config["optim"]["num_workers"],
-                    pin_memory=True,
-                )
-
-            if "relax_dataset" in self.config["task"]:
-                assert os.path.isfile(
-                    self.config["task"]["relax_dataset"]["src"]
-                )
-
-                self.relax_dataset = registry.get_dataset_class(
-                    "single_point_lmdb"
-                )(self.config["task"]["relax_dataset"])
-
-                self.relax_sampler = DistributedSampler(
-                    self.relax_dataset,
                     num_replicas=distutils.get_world_size(),
                     rank=distutils.get_rank(),
                     shuffle=False,
                 )
-                self.relax_loader = DataLoader(
-                    self.relax_dataset,
-                    batch_size=self.config["optim"].get("eval_batch_size", 64),
+                self.test_loader = DataLoader(
+                    self.test_dataset,
+                    self.config["optim"].get("eval_batch_size", 64),
                     collate_fn=self.parallel_collater,
                     num_workers=self.config["optim"]["num_workers"],
                     pin_memory=True,
-                    sampler=self.relax_sampler,
+                    sampler=self.test_sampler,
                 )
 
-        else:
-            self.dataset = registry.get_dataset_class(
-                self.config["task"]["dataset"]
-            )(self.config["dataset"])
-            (
-                self.train_loader,
-                self.val_loader,
-                self.test_loader,
-            ) = self.dataset.get_dataloaders(
-                batch_size=self.config["optim"]["batch_size"],
+        if "relax_dataset" in self.config["task"]:
+            assert os.path.isfile(self.config["task"]["relax_dataset"]["src"])
+
+            self.relax_dataset = registry.get_dataset_class(
+                "single_point_lmdb"
+            )(self.config["task"]["relax_dataset"])
+
+            self.relax_sampler = DistributedSampler(
+                self.relax_dataset,
+                num_replicas=distutils.get_world_size(),
+                rank=distutils.get_rank(),
+                shuffle=False,
+            )
+            self.relax_loader = DataLoader(
+                self.relax_dataset,
+                batch_size=self.config["optim"].get("eval_batch_size", 64),
                 collate_fn=self.parallel_collater,
+                num_workers=self.config["optim"]["num_workers"],
+                pin_memory=True,
+                sampler=self.relax_sampler,
             )
 
         self.num_targets = 1


### PR DESCRIPTION
Rather than splitting LMDBs across all processes, split all data across all processes to avoid issues when # of GPUs are much larger than # of LMDBs. Allows us to leverage the DistributedSampler instead of writing our own custom partitioning scheme. 

I benchmark timings of SchNet-200k for 10 epochs on 4 nodes, 32 effective GPUs (NOTE - nodes here were not controlled, which could explain the variability in training times):
```
train
Old:  918.3643939495087
New: 1105.6444401741028

pred
Old: 273.68402218818665
New: 225.97153663635254
```

To control for system differences, I ran things locally on 2 GPUs for a single epoch:

```
train
Old: 663.723126411438s
New: 662.4184503555298
```