### PR TITLE
Accomodate cpu only predictions using main.py

### DIFF
--- a/ocpmodels/common/relaxation/ase_utils.py
+++ b/ocpmodels/common/relaxation/ase_utils.py
@@ -101,11 +101,11 @@ class OCPCalculator(Calculator):
             batch.edge_index = edge_index
             batch.cell_offsets = cell_offsets
             batch.neighbors = neighbors
-        if self.trainer.name == 's2ef':
-            predictions = self.trainer.predict(batch, per_image=False)
+
+        predictions = self.trainer.predict(batch, per_image=False)
+        if self.trainer.name == "s2ef":
             self.results["energy"] = predictions["energy"].item()
             self.results["forces"] = predictions["forces"].cpu().numpy()
 
-        elif self.trainer.name == 'is2re':
-            predictions = self.trainer.predict(batch)
+        elif self.trainer.name == "is2re":
             self.results["energy"] = predictions["energy"]

--- a/ocpmodels/common/relaxation/ase_utils.py
+++ b/ocpmodels/common/relaxation/ase_utils.py
@@ -101,7 +101,11 @@ class OCPCalculator(Calculator):
             batch.edge_index = edge_index
             batch.cell_offsets = cell_offsets
             batch.neighbors = neighbors
-        predictions = self.trainer.predict(batch, per_image=False)
+        if self.trainer.name == 's2ef':
+            predictions = self.trainer.predict(batch, per_image=False)
+            self.results["energy"] = predictions["energy"].item()
+            self.results["forces"] = predictions["forces"].cpu().numpy()
 
-        self.results["energy"] = predictions["energy"].item()
-        self.results["forces"] = predictions["forces"].cpu().numpy()
+        elif self.trainer.name == 'is2re':
+            predictions = self.trainer.predict(batch)
+            self.results["energy"] = predictions["energy"]

--- a/ocpmodels/common/relaxation/ase_utils.py
+++ b/ocpmodels/common/relaxation/ase_utils.py
@@ -108,4 +108,4 @@ class OCPCalculator(Calculator):
             self.results["forces"] = predictions["forces"].cpu().numpy()
 
         elif self.trainer.name == "is2re":
-            self.results["energy"] = predictions["energy"]
+            self.results["energy"] = predictions["energy"].item()

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -245,7 +245,7 @@ class BaseTrainer(ABC):
 
     @abstractmethod
     def load_task(self):
-        """ Derived classes should implement this function."""
+        """Derived classes should implement this function."""
 
     def load_model(self):
         # Build model
@@ -301,7 +301,13 @@ class BaseTrainer(ABC):
             return False
 
         print("### Loading checkpoint from: {}".format(checkpoint_path))
-        checkpoint = torch.load(checkpoint_path)
+
+        if self.cpu:
+            checkpoint = torch.load(
+                checkpoint_path, map_location=torch.device("cpu")
+            )
+        else:
+            checkpoint = torch.load(checkpoint_path)
         self.start_step = checkpoint.get("step", 0)
 
         # Load model, optimizer, normalizer state dict.
@@ -412,7 +418,7 @@ class BaseTrainer(ABC):
 
     @abstractmethod
     def train(self):
-        """ Derived classes should implement this function."""
+        """Derived classes should implement this function."""
 
     @torch.no_grad()
     def validate(self, split="val", epoch=None, disable_tqdm=False):
@@ -476,11 +482,11 @@ class BaseTrainer(ABC):
 
     @abstractmethod
     def _forward(self, batch_list):
-        """ Derived classes should implement this function."""
+        """Derived classes should implement this function."""
 
     @abstractmethod
     def _compute_loss(self, out, batch_list):
-        """ Derived classes should implement this function."""
+        """Derived classes should implement this function."""
 
     def _backward(self, loss):
         self.optimizer.zero_grad()

--- a/ocpmodels/trainers/energy_trainer.py
+++ b/ocpmodels/trainers/energy_trainer.py
@@ -182,7 +182,9 @@ class EnergyTrainer(BaseTrainer):
                 raise NotImplementedError
 
     @torch.no_grad()
-    def predict(self, loader, results_file=None, disable_tqdm=False):
+    def predict(
+        self, loader, per_image=True, results_file=None, disable_tqdm=False
+    ):
         if distutils.is_master() and not disable_tqdm:
             print("### Predicting on test.")
         assert isinstance(
@@ -216,14 +218,15 @@ class EnergyTrainer(BaseTrainer):
                 out["energy"] = self.normalizers["target"].denorm(
                     out["energy"]
                 )
-            try:
-                predictions["id"].extend([str(i) for i in batch[0].sid.tolist()])
-            except:
-                #Not sure what we would want here or if something would work better in general
-                predictions["id"] == 'Unassigned'
-            predictions["energy"].extend(out["energy"].tolist())
 
-        self.save_results(predictions, results_file, keys=["energy"])
+            predictions["energy"].extend(out["energy"].tolist())
+            if per_image:
+                predictions["id"].extend(
+                    [str(i) for i in batch[0].sid.tolist()]
+                )
+                predictions["energy"].extend(out["energy"].tolist())
+                self.save_results(predictions, results_file, keys=["energy"])
+
         return predictions
 
     def train(self):

--- a/ocpmodels/trainers/energy_trainer.py
+++ b/ocpmodels/trainers/energy_trainer.py
@@ -219,13 +219,16 @@ class EnergyTrainer(BaseTrainer):
                     out["energy"]
                 )
 
-            predictions["energy"].extend(out["energy"].tolist())
             if per_image:
                 predictions["id"].extend(
                     [str(i) for i in batch[0].sid.tolist()]
                 )
                 predictions["energy"].extend(out["energy"].tolist())
-                self.save_results(predictions, results_file, keys=["energy"])
+            else:
+                predictions["energy"] = out["energy"].detach()
+                return predictions
+
+        self.save_results(predictions, results_file, keys=["energy"])
 
         return predictions
 


### PR DESCRIPTION
torch.load(checkpoint_path) requires that a map location be specified for cpu only. Added an if statement that does just this in the case where cpu only is used. @mshuaibii 