### PR TITLE
IS2RE relaxation scripts

### DIFF
--- a/TRAIN.md
+++ b/TRAIN.md
@@ -72,6 +72,37 @@ python main.py --mode predict --config-yml configs/is2re/10k/schnet/schnet.yml \
 ```
 The predictions are stored in `[RESULTS_DIR]/is2re_predictions.npz` and later used to create a submission file to be uploaded to EvalAI.
 
+### IS2RE Relaxations
+Alternatively, the IS2RE task may be approached by 2 methods as described in our paper:
+
+- Single Model: Relaxed energy predictions are extracted from relaxed structures generated via ML relaxations from a single model.
+
+    1. Train a S2EF model on both energy and forces as described [here](https://github.com/Open-Catalyst-Project/ocp/blob/master/TRAIN.md#structure-to-energy-and-forces-s2ef)
+    2. Using the trained S2EF model, run ML relaxations as described [here](https://github.com/Open-Catalyst-Project/ocp/blob/master/TRAIN.md#initial-structure-to-relaxed-structure-is2rs). Ensure `traj_dir` is uniquely specified in the config as to save out the full trajectory. **Note** Relaxations on the complete val/test set may take upwards of 8hrs depending on your available hardware.
+    3. Prepare a submission file by running the following command:
+        ```
+        python scripts/make_sibmission_file.py --id path/to/id/traj_dir \ 
+                --ood-ads path/to/ood_ads/traj_dir --ood-cat path/to/ood_cat/traj_dir \
+                --ood-both path/to/ood_both/traj_dir --out-path submission_file.npz --is2re-relaxations
+        ```
+- Dual Model: Relaxed energy predictions are extracted from relaxed structures generated via ML relaxations from two models - one for running relaxations and one for making energy predictions.
+    1. Train two S2EF models, energy-only and force-only.
+    2. Using the trained force-only S2EF model, run ML relaxations as described previously. Ensure `traj_dir` is uniquely specified in the config as to save out the full trajectory. **Note** Relaxations on the complete val/test set may take upwards of 8hrs depending on your available hardware. 
+    3. In order to make predictions via the energy-only model on the generated trajectories, LMDBs must be constructed via the following command:
+        ```
+        python scripts/preprocess_relaxed.py --id path/to/id/traj_dir \
+              --ood-ads path/to/ood_ads/traj_dir --ood-cat path/to/ood_cat/traj_dir \
+              --ood-both path/to/ood_both/traj_dir --out-path $DIR --num-workers $NUM_WORKERS
+        ``` 
+        Where `$DIR` specifies the directory to save generated LMDBs. A sub-directory will be created for each of the 4 splits in `$DIR`. `$NUM_WORKERS` is the number of data preprocessing cpu workers to be used.
+    4. Update your energy-only config to point the test set to the newly generated LMDBs. Using the trained energy-only S2EF model, generate predictions via `--mode predict` (as you would do for the general IS2RE/S2EF case).
+    5. Prepare a submission file by running the following command: 
+        ```
+        python scripts/make_sibmission_file.py --id path/to/id/s2ef_predictions.npz \ 
+                --ood-ads path/to/ood_ads/s2ef_predictions.npz --ood-cat path/to/ood_cat/s2ef_predictions.npz \
+                --ood-both path/to/ood_both/s2ef_predictions.npz --out-path submission_file.npz \
+                --is2re-relaxations --hybrid
+        ```
 ## Structure to Energy and Forces (S2EF)
 
 In the S2EF task, the model takes the positions of the atoms as input and predicts the energy and per-atom
@@ -146,11 +177,21 @@ EvalAI expects results to be structured in a specific format for a submission to
 
 ### S2EF/IS2RE:
 1. Run predictions `--mode predict` on all 4 splits, generating `[s2ef/is2re]_predictions.npz` files for each split.
-2. Modify `scripts/make_submission_file.py` with the corresponding paths of the `[s2ef/is2re]_predictions.npz` files and run to generate your final submission file `[s2ef/is2re]_submission.npz` (filename may be modified).
-3. Upload `[s2ef/is2re]_submission.npz` to EvalAI.
+2. Run the following command:
+    ```
+    python make_submission_file.py --id path/to/id/file.npz --ood-ads path/to/ood_ads/file.npz \
+    --ood-cat path/to/ood_cat/file.npz --ood-both path/to/ood_both/file.npz --out-path submission_file.npz
+    ```
+   Where `file.npz` corresponds to the respective `[s2ef/is2re]_predictions.npz` files generated for the corresponding task. The final submission file will be written to `submission_file.npz` (rename accordingly).
+3. Upload `submission_file.npz` to EvalAI.
 
 
 ### IS2RS:
 1. Ensure `write_pos: True` is included in your configuration file. Run relaxations `--mode run-relaxations` on all 4 splits, generating `relaxed_positions.npz` files for each split.
-2. Modify `scripts/make_submission_file.py` with the corresponding paths of the `relaxed_positions.npz` files and run to generate your final submission file `[is2rs]_submission.npz` (filename may be modified).
+2. Run the following command:
+    ```
+    python make_submission_file.py --id path/to/id/relaxed_positions.npz --ood-ads path/to/ood_ads/relaxed_positions.npz \
+    --ood-cat path/to/ood_cat/relaxed_positions.npz --ood-both path/to/ood_both/relaxed_positions.npz --out-path is2rs_submission.npz
+    ```
+   The final submission file will be written to `is2rs_submission.npz` (rename accordingly).
 3. Upload `is2rs_submission.npz` to EvalAI.

--- a/TRAIN.md
+++ b/TRAIN.md
@@ -78,7 +78,7 @@ Alternatively, the IS2RE task may be approached by 2 methods as described in our
 - Single Model: Relaxed energy predictions are extracted from relaxed structures generated via ML relaxations from a single model.
 
     1. Train a S2EF model on both energy and forces as described [here](https://github.com/Open-Catalyst-Project/ocp/blob/master/TRAIN.md#structure-to-energy-and-forces-s2ef)
-    2. Using the trained S2EF model, run ML relaxations as described [here](https://github.com/Open-Catalyst-Project/ocp/blob/master/TRAIN.md#initial-structure-to-relaxed-structure-is2rs). Ensure `traj_dir` is uniquely specified in the config as to save out the full trajectory. **Note** Relaxations on the complete val/test set may take upwards of 8hrs depending on your available hardware.
+    2. Using the trained S2EF model, run ML relaxations as described [here](https://github.com/Open-Catalyst-Project/ocp/blob/master/TRAIN.md#initial-structure-to-relaxed-structure-is2rs). Ensure `traj_dir` is uniquely specified in the config as to save out the full trajectory. A sample config can be found [here](https://github.com/Open-Catalyst-Project/ocp/blob/master/configs/s2ef/2M/dimenet_plus_plus/dpp_relax.yml). ** Note ** Relaxations on the complete val/test set may take upwards of 8hrs depending on your available hardware.
     3. Prepare a submission file by running the following command:
         ```
         python scripts/make_sibmission_file.py --id path/to/id/traj_dir \ 

--- a/configs/s2ef/2M/dimenet_plus_plus/dpp_relax.yml
+++ b/configs/s2ef/2M/dimenet_plus_plus/dpp_relax.yml
@@ -1,0 +1,68 @@
+trainer: forces
+
+dataset:
+  - src: data/s2ef/2M/train/
+    normalize_labels: True
+    target_mean: -0.7554450631141663
+    target_std: 2.887317180633545
+    grad_target_mean: 0.0
+    grad_target_std: 2.887317180633545
+  - src: data/s2ef/all/val_id/
+
+logger: tensorboard
+
+task:
+  dataset: trajectory_lmdb
+  description: "Regressing to energies and forces for DFT trajectories from OCP"
+  type: regression
+  metric: mae
+  labels:
+    - potential energy
+  grad_input: atomic forces
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  relax_dataset:
+    src: data/is2re/all/test_id/data.lmdb
+  write_pos: True
+  relaxation_steps: 200
+  relax_opt:
+    maxstep: 0.04
+    memory: 50
+    damping: 1.0
+    alpha: 70.0
+    traj_dir: "ml-relaxations/dpp-2M-test-id"
+
+model:
+  name: dimenetplusplus
+  hidden_channels: 192
+  out_emb_channels: 192
+  num_blocks: 3
+  cutoff: 6.0
+  num_radial: 6
+  num_spherical: 7
+  num_before_skip: 1
+  num_after_skip: 2
+  num_output_layers: 3
+  regress_forces: True
+  use_pbc: True
+
+# *** Important note ***
+#   The total number of gpus used for this run was 32.
+#   If the global batch size (num_gpus * batch_size) is modified
+#   the lr_milestones and warmup_steps need to be adjusted accordingly.
+
+optim:
+  batch_size: 12
+  eval_batch_size: 12
+  eval_every: 10000
+  num_workers: 8
+  lr_initial: 0.0001
+  lr_gamma: 0.1
+  lr_milestones: # steps at which lr_initial <- lr_initial * lr_gamma
+    - 20833
+    - 31250
+    - 41666
+  warmup_steps: 10416
+  warmup_factor: 0.2
+  max_epochs: 15
+  force_coefficient: 50

--- a/scripts/preprocess_relaxed.py
+++ b/scripts/preprocess_relaxed.py
@@ -1,0 +1,145 @@
+"""
+Creates LMDB files with extracted graph features from provided *.extxyz files
+for the S2EF task.
+"""
+
+import argparse
+import glob
+import multiprocessing as mp
+import os
+import pickle
+import random
+import sys
+
+import ase.io
+import lmdb
+import numpy as np
+import torch
+from tqdm import tqdm
+
+from ocpmodels.preprocessing import AtomsToGraphs
+
+
+def write_images_to_lmdb(mp_arg):
+    a2g, db_path, samples, pid = mp_arg
+    db = lmdb.open(
+        db_path,
+        map_size=1099511627776 * 2,
+        subdir=False,
+        meminit=False,
+        map_async=True,
+    )
+
+    pbar = tqdm(
+        total=len(samples),
+        position=pid,
+        desc="Preprocessing data into LMDBs",
+    )
+    idx = 0
+    for sample in samples:
+        ml_relaxed = ase.io.read(sample, "-1")
+        data_object = a2g.convert(ml_relaxed)
+
+        sid, _ = os.path.splitext(os.path.basename(sample))
+        fid = -1
+        # add atom tags
+        data_object.tags = torch.LongTensor(ml_relaxed.get_tags())
+        data_object.sid = int(sid)
+        data_object.fid = fid
+
+        txn = db.begin(write=True)
+        txn.put(
+            f"{idx}".encode("ascii"),
+            pickle.dumps(data_object, protocol=-1),
+        )
+        txn.commit()
+        idx += 1
+        pbar.update(1)
+
+    # Save count of objects in lmdb.
+    txn = db.begin(write=True)
+    txn.put("length".encode("ascii"), pickle.dumps(idx, protocol=-1))
+    txn.commit()
+
+    db.sync()
+    db.close()
+
+
+def main(args, split):
+    systems = glob.glob(f"{eval(f'args.{split}')}/*.traj")
+
+    systems_chunked = np.array_split(systems, args.num_workers)
+
+    # Initialize feature extractor.
+    a2g = AtomsToGraphs(
+        max_neigh=50,
+        radius=6,
+        r_energy=False,
+        r_forces=False,
+        r_distances=False,
+        r_fixed=True,
+        r_edges=True,
+    )
+
+    # Create output directory if it doesn't exist.
+    out_path = f"{args.out_path}_{split}"
+    os.makedirs(out_path, exist_ok=True)
+
+    # Initialize lmdb paths
+    db_paths = [
+        os.path.join(out_path, "data.%04d.lmdb" % i)
+        for i in range(args.num_workers)
+    ]
+
+    pool = mp.Pool(args.num_workers)
+    mp_args = [
+        (
+            a2g,
+            db_paths[i],
+            systems_chunked[i],
+            i,
+        )
+        for i in range(args.num_workers)
+    ]
+    list(pool.imap(write_images_to_lmdb, mp_args))
+    pool.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--id",
+        required=True,
+        help="Path to ID trajectories",
+    )
+    parser.add_argument(
+        "--ood-ads",
+        required=True,
+        help="Path to OOD-Ads trajectories",
+    )
+    parser.add_argument(
+        "--ood-cat",
+        required=True,
+        help="Path to OOD-Cat trajectories",
+    )
+    parser.add_argument(
+        "--ood-both",
+        required=True,
+        help="Path to OOD-Both trajectories",
+    )
+    parser.add_argument(
+        "--out-path",
+        required=True,
+        help="Directory to save extracted features. Will create if doesn't exist",
+    )
+    parser.add_argument(
+        "--num-workers",
+        type=int,
+        default=1,
+        help="No. of feature-extracting processes.",
+    )
+
+    args = parser.parse_args()
+
+    for split in ["id", "ood_ads", "ood_cat", "ood_both"]:
+        main(args, split)


### PR DESCRIPTION
Following the updates found [here](https://discuss.opencatalystproject.org/t/is2re-table-4-corrections/59), this PR includes and updates scripts to allow for IS2RE relaxation approaches via the 2 approaches discussed in the linked table:

1. Train an S2EF model (energy+forces), run ML relaxations (saving out trajectories), create submission files via trajectory files.
2. Train 2 S2EF models, a force-only and an energy-only model. Run ML relaxations (saving out trajectories) via the force-only model, create LMDB files from the generated trajectories, make predictions via the energy-only model.

## Changes 
- Modifies https://github.com/Open-Catalyst-Project/ocp/blob/master/scripts/make_submission_file.py to take in command line arguments. Includes additional methods to create submission files for IS2RE relaxation outputs.
- Includes a sample DimeNet++ 2M config to run relaxations.
- Includes a script to generate LMDBs from relaxation trajectories to be used for S2EF predictions.

## Example
- To make predictions on standard IS2RE, S2EF, IS2RS tasks:
```
python make_submission_file.py --id path/to/id/file.npz --ood-ads path/to/ood_ads/file.npz --ood-cat path/to/ood_cat/file.npz --ood-both path/to/ood_both/file.npz --out-path submission_file.npz
```
- To make IS2RE relaxation predictions via approach 1:
```
python make_submission_file.py --id path/to/id/traj/dir --ood-ads path/to/ood_ads/traj/dir --ood-cat path/to/ood_cat/traj/dir --ood-both path/to/ood_both/traj/dir --out-path submission_file.npz --is2re-relaxations
```
- To make IS2RE relaxation predictions via approach 2:
```
python make_submission_file.py --id path/to/id/s2ef_predictions.npz --ood-ads path/to/ood_ads/s2ef_predictions.npz --ood-cat path/to/ood_cat/s2ef_predictions.npz --ood-both path/to/ood_both/s2ef_predictions.npz --out-path submission_file.npz --is2re-relaxations --hybrid
```

## TODOs
- Include detailed documentation for IS2RE relaxations to make use of the above.