### PR TITLE
Support for ignoring specified directories within `experimental`

### DIFF
--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -265,7 +265,9 @@ def setup_imports():
         if os.path.exists(ignore_file):
             with open(ignore_file) as f:
                 for line in f.read().splitlines():
-                    ignored += glob.glob(experimental_folder + line + "/**/*py", recursive=True)
+                    ignored += glob.glob(
+                        experimental_folder + line + "/**/*py", recursive=True
+                    )
             for f in ignored:
                 experimental_files.remove(f)
         for f in experimental_files:

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -261,8 +261,9 @@ def setup_imports():
             recursive=True,
         )
         # Ignore certain directories within experimental
-        ignore_file, ignored = os.path.join(experimental_folder, ".ignore"), []
+        ignore_file = os.path.join(experimental_folder, ".ignore")
         if os.path.exists(ignore_file):
+            ignored = []
             with open(ignore_file) as f:
                 for line in f.read().splitlines():
                     ignored += glob.glob(

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -260,6 +260,14 @@ def setup_imports():
             experimental_folder + "**/*py",
             recursive=True,
         )
+        # Ignore certain directories within experimental
+        ignore_file, ignored = os.path.join(experimental_folder, ".ignore"), []
+        if os.path.exists(ignore_file):
+            with open(ignore_file) as f:
+                for line in f.read().splitlines():
+                    ignored += glob.glob(experimental_folder + line + "/**/*py", recursive=True)
+            for f in ignored:
+                experimental_files.remove(f)
         for f in experimental_files:
             splits = f.split(os.sep)
             file_name = ".".join(splits[-splits[::-1].index("..") :])


### PR DESCRIPTION
Looks for an `experimental/.ignore` file and removes those paths from being imported.

Example `.ignore`:
```
abc
def
```
would ignore `experimental/abc/*py`, `experimental/def/*py`.