### PR TITLE
bugfix: remove epoch arg from validate

### DIFF
--- a/ocpmodels/trainers/energy_trainer.py
+++ b/ocpmodels/trainers/energy_trainer.py
@@ -331,9 +331,6 @@ class EnergyTrainer(BaseTrainer):
                     if self.val_loader is not None:
                         val_metrics = self.validate(
                             split="val",
-                            epoch=self.epoch
-                            - 1
-                            + (i + 1) / len(self.train_loader),
                             disable_tqdm=disable_eval_tqdm,
                         )
                         if (


### PR DESCRIPTION
Re  #260 - Post-merge change: `validate` no longer takes `epoch` as an argument. This was resolved for `forces_trainer` but not `energy_trainer`.