### PR TITLE
Load balancing

### DIFF
--- a/env.common.yml
+++ b/env.common.yml
@@ -18,6 +18,7 @@ dependencies:
   - nbsphinx
   - pandoc
   - black
+  - numba
   - pip:
     - demjson
     - Pillow

--- a/main.py
+++ b/main.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
             timeout_min=args.slurm_timeout * 60,
             slurm_partition=args.slurm_partition,
             gpus_per_node=args.num_gpus,
-            cpus_per_task=(args.num_workers + 1),
+            cpus_per_task=(config["optim"]["num_workers"] + 1),
             tasks_per_node=(args.num_gpus if args.distributed else 1),
             nodes=args.num_nodes,
             slurm_additional_parameters=slurm_add_params,

--- a/ocpmodels/common/data_parallel.py
+++ b/ocpmodels/common/data_parallel.py
@@ -5,10 +5,16 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
+import heapq
+import logging
 from itertools import chain
 
+import numba
+import numpy as np
 import torch
+from torch.utils.data import BatchSampler, DistributedSampler, Sampler
 
+from ocpmodels.common import distutils
 from ocpmodels.datasets import data_list_collater
 
 
@@ -76,7 +82,7 @@ class ParallelCollater:
         self.otf_graph = otf_graph
 
     def __call__(self, data_list):
-        if self.num_gpus == 0 or self.num_gpus == 1:  # adds cpu-only case
+        if self.num_gpus in [0, 1]:  # adds cpu-only case
             batch = data_list_collater(data_list, otf_graph=self.otf_graph)
             return [batch]
 
@@ -100,3 +106,138 @@ class ParallelCollater:
                 data_list_collater(data_list[split[i] : split[i + 1]])
                 for i in range(len(split) - 1)
             ]
+
+
+@numba.njit
+def balanced_partition(sizes, num_parts):
+    """
+    Greedily partition the given set by always inserting
+    the largest element into the smallest partition.
+    """
+    sort_idx = np.argsort(-sizes)  # Sort in descending order
+    heap = []
+    for idx in sort_idx[:num_parts]:
+        heap.append((sizes[idx], [idx]))
+    heapq.heapify(heap)
+    for idx in sort_idx[num_parts:]:
+        smallest_part = heapq.heappop(heap)
+        new_size = smallest_part[0] + sizes[idx]
+        new_idx = smallest_part[1] + [idx]
+        heapq.heappush(heap, (new_size, new_idx))
+    idx_balanced = [part[1] for part in heap]
+    return idx_balanced
+
+
+class BalancedBatchSampler(Sampler):
+    def __init__(
+        self,
+        dataset,
+        batch_size,
+        num_replicas,
+        rank,
+        device,
+        mode="atoms",
+        shuffle=True,
+        drop_last=False,
+        force_balancing=False,
+    ):
+        self.dataset = dataset
+        self.batch_size = batch_size
+        self.num_replicas = num_replicas
+        self.rank = rank
+        self.device = device
+        self.mode = mode.lower()
+        self.shuffle = shuffle
+        self.drop_last = drop_last
+
+        self.balance_batches = self.num_replicas > 1
+        if self.balance_batches:
+            if (
+                not hasattr(dataset, "metadata_path")
+                or not dataset.metadata_path.is_file()
+            ):
+                if force_balancing:
+                    logging.warning(
+                        f"No metadata file found at '{dataset.metadata_path}'. "
+                        "BalancedBatchSampler has to load the data to "
+                        "determine batch sizes, which incurs "
+                        "significant overhead!"
+                    )
+                    self.sizes = None
+                else:
+                    logging.warning(
+                        f"No metadata file found at '{dataset.metadata_path}'. "
+                        "Batches will not be balanced, "
+                        "which can incur significant overhead!"
+                    )
+                    self.balance_batches = False
+                    self.sizes = None
+            else:
+                if self.mode == "atoms":
+                    self.sizes = np.load(dataset.metadata_path)["natoms"]
+                elif self.mode == "neighbors":
+                    self.sizes = np.load(dataset.metadata_path)["neighbors"]
+                else:
+                    raise NotImplementedError(
+                        f"Unknown load balancing mode: {self.mode}"
+                    )
+        else:
+            self.sizes = None
+
+        self.single_sampler = DistributedSampler(
+            dataset,
+            num_replicas=num_replicas,
+            rank=rank,
+            shuffle=shuffle,
+            drop_last=drop_last,
+        )
+        self.batch_sampler = BatchSampler(
+            self.single_sampler,
+            batch_size,
+            drop_last=drop_last,
+        )
+
+    def __len__(self):
+        return len(self.batch_sampler)
+
+    def set_epoch(self, epoch):
+        self.single_sampler.set_epoch(epoch)
+
+    def __iter__(self):
+        for batch_idx in self.batch_sampler:
+            if self.balance_batches:
+                if self.sizes is None:
+                    # Unfortunately, we need to load the data to know the image sizes
+                    data_list = [self.dataset[idx] for idx in batch_idx]
+
+                    if self.mode == "atoms":
+                        sizes = [data.num_nodes for data in data_list]
+                    elif self.mode == "neighbors":
+                        sizes = [
+                            data.edge_index.shape[1] for data in data_list
+                        ]
+                    else:
+                        raise NotImplementedError(
+                            f"Unknown load balancing mode: {self.mode}"
+                        )
+                else:
+                    sizes = [self.sizes[idx] for idx in batch_idx]
+
+                idx_sizes = torch.stack(
+                    [torch.tensor(batch_idx), torch.tensor(sizes)]
+                )
+                idx_sizes_all = distutils.all_gather(
+                    idx_sizes, device=self.device
+                )
+                idx_sizes_all = torch.cat(idx_sizes_all, dim=-1).cpu()
+                idx_all = idx_sizes_all[0]
+                sizes_all = idx_sizes_all[1]
+
+                local_idx_balanced = balanced_partition(
+                    sizes_all.numpy(), num_parts=self.num_replicas
+                )
+                # Since DistributedSampler pads the last batch
+                # this should always have an entry for each replica.
+                yield idx_all[local_idx_balanced[self.rank]]
+            else:
+                yield batch_idx

--- a/ocpmodels/common/flags.py
+++ b/ocpmodels/common/flags.py
@@ -56,12 +56,6 @@ class Flags:
             help="Whether to visualize a few extra things",
         )
         self.parser.add_argument(
-            "--num-workers",
-            default=0,
-            type=int,
-            help="Number of dataloader workers (default: 0 i.e. use main proc)",
-        )
-        self.parser.add_argument(
             "--print-every",
             default=10,
             type=int,

--- a/ocpmodels/datasets/single_point_lmdb.py
+++ b/ocpmodels/datasets/single_point_lmdb.py
@@ -5,8 +5,10 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
+import errno
 import os
 import pickle
+from pathlib import Path
 
 import lmdb
 from torch.utils.data import Dataset
@@ -28,12 +30,13 @@ class SinglePointLmdbDataset(Dataset):
     def __init__(self, config, transform=None):
         super(SinglePointLmdbDataset, self).__init__()
 
-        self.config = config
+        self.db_path = Path(self.config["src"])
+        if not self.db_path.is_file():
+            raise FileNotFoundError(
+                errno.ENOENT, "LMDB file not found", str(self.db_path)
+            )
 
-        self.db_path = self.config["src"]
-        assert os.path.isfile(self.db_path), "{} not found".format(
-            self.db_path
-        )
+        self.metadata_path = self.db_path.parent / "metadata.npz"
 
         self.env = self.connect_db(self.db_path)
 
@@ -59,7 +62,7 @@ class SinglePointLmdbDataset(Dataset):
 
     def connect_db(self, lmdb_path=None):
         env = lmdb.open(
-            lmdb_path,
+            str(lmdb_path),
             subdir=False,
             readonly=True,
             lock=False,

--- a/ocpmodels/datasets/single_point_lmdb.py
+++ b/ocpmodels/datasets/single_point_lmdb.py
@@ -30,6 +30,8 @@ class SinglePointLmdbDataset(Dataset):
     def __init__(self, config, transform=None):
         super(SinglePointLmdbDataset, self).__init__()
 
+        self.config = config
+
         self.db_path = Path(self.config["src"])
         if not self.db_path.is_file():
             raise FileNotFoundError(

--- a/ocpmodels/datasets/trajectory_lmdb.py
+++ b/ocpmodels/datasets/trajectory_lmdb.py
@@ -40,7 +40,9 @@ class TrajectoryLmdbDataset(Dataset):
 
         srcdir = Path(self.config["src"])
         db_paths = sorted(srcdir.glob("*.lmdb"))
-        assert len(db_paths) > 0, f"No LMDBs found in {srcdir}"
+        assert len(db_paths) > 0, f"No LMDBs found in '{srcdir}'"
+
+        self.metadata_path = srcdir / "metadata.npz"
 
         self._keys, self.envs = [], []
         for db_path in db_paths:

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -12,8 +12,7 @@ import os
 import random
 import subprocess
 from abc import ABC, abstractmethod
-from collections import OrderedDict, defaultdict
-from pathlib import Path
+from collections import defaultdict
 
 import numpy as np
 import torch
@@ -22,11 +21,15 @@ import torch.optim as optim
 import yaml
 from ray import tune
 from torch.nn.parallel.distributed import DistributedDataParallel
+from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 import ocpmodels
 from ocpmodels.common import distutils
-from ocpmodels.common.data_parallel import OCPDataParallel
+from ocpmodels.common.data_parallel import (
+    BalancedBatchSampler,
+    OCPDataParallel,
+)
 from ocpmodels.common.registry import registry
 from ocpmodels.common.utils import (
     build_config,
@@ -222,6 +225,36 @@ class BaseTrainer(ABC):
             self.logger = registry.get_logger_class(self.config["logger"])(
                 self.config
             )
+
+    def get_sampler(self, dataset, batch_size, shuffle):
+        if "load_balancing" in self.config["optim"]:
+            balancing_mode = self.config["optim"]["load_balancing"]
+            force_balancing = True
+        else:
+            balancing_mode = "atoms"
+            force_balancing = False
+
+        sampler = BalancedBatchSampler(
+            dataset,
+            batch_size=batch_size,
+            num_replicas=distutils.get_world_size(),
+            rank=distutils.get_rank(),
+            device=self.device,
+            mode=balancing_mode,
+            shuffle=shuffle,
+            force_balancing=force_balancing,
+        )
+        return sampler
+
+    def get_dataloader(self, dataset, sampler):
+        loader = DataLoader(
+            dataset,
+            collate_fn=self.parallel_collater,
+            num_workers=self.config["optim"]["num_workers"],
+            pin_memory=True,
+            batch_sampler=sampler,
+        )
+        return loader
 
     @abstractmethod
     def load_task(self):

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -177,9 +177,6 @@ class ForcesTrainer(BaseTrainer):
             self.relax_loader = self.get_dataloader(
                 self.relax_dataset,
                 self.relax_sampler,
-                self.config["optim"].get(
-                    "eval_batch_size", self.config["optim"]["batch_size"]
-                ),
             )
 
         self.num_targets = 1

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -12,7 +12,6 @@ from collections import defaultdict
 import numpy as np
 import torch
 import torch_geometric
-from torch.utils.data import DataLoader, DistributedSampler
 from tqdm import tqdm
 
 from ocpmodels.common import distutils
@@ -112,7 +111,7 @@ class ForcesTrainer(BaseTrainer):
         logging.info(f"Loading dataset: {self.config['task']['dataset']}")
 
         self.parallel_collater = ParallelCollater(
-            1 if not self.cpu else 0,
+            0 if self.cpu else 1,
             self.config["model_attributes"].get("otf_graph", False),
         )
         if self.config["task"]["dataset"] == "trajectory_lmdb":
@@ -121,58 +120,45 @@ class ForcesTrainer(BaseTrainer):
                 self.train_dataset = registry.get_dataset_class(
                     self.config["task"]["dataset"]
                 )(self.config["dataset"])
-
-                self.train_sampler = DistributedSampler(
+                self.train_sampler = self.get_sampler(
                     self.train_dataset,
-                    num_replicas=distutils.get_world_size(),
-                    rank=distutils.get_rank(),
+                    self.config["optim"]["batch_size"],
                     shuffle=True,
                 )
-
-                self.train_loader = DataLoader(
+                self.train_loader = self.get_dataloader(
                     self.train_dataset,
-                    batch_size=self.config["optim"]["batch_size"],
-                    collate_fn=self.parallel_collater,
-                    num_workers=self.config["optim"]["num_workers"],
-                    pin_memory=True,
-                    sampler=self.train_sampler,
+                    self.train_sampler,
                 )
 
             if self.config.get("val_dataset", None):
                 self.val_dataset = registry.get_dataset_class(
                     self.config["task"]["dataset"]
                 )(self.config["val_dataset"])
-                self.val_sampler = DistributedSampler(
+                self.val_sampler = self.get_sampler(
                     self.val_dataset,
-                    num_replicas=distutils.get_world_size(),
-                    rank=distutils.get_rank(),
+                    self.config["optim"].get(
+                        "eval_batch_size", self.config["optim"]["batch_size"]
+                    ),
                     shuffle=False,
                 )
-                self.val_loader = DataLoader(
+                self.val_loader = self.get_dataloader(
                     self.val_dataset,
-                    self.config["optim"].get("eval_batch_size", 64),
-                    collate_fn=self.parallel_collater,
-                    num_workers=self.config["optim"]["num_workers"],
-                    pin_memory=True,
-                    sampler=self.val_sampler,
+                    self.val_sampler,
                 )
             if self.config.get("test_dataset", None):
                 self.test_dataset = registry.get_dataset_class(
                     self.config["task"]["dataset"]
                 )(self.config["test_dataset"])
-                self.test_sampler = DistributedSampler(
+                self.test_sampler = self.get_sampler(
                     self.test_dataset,
-                    num_replicas=distutils.get_world_size(),
-                    rank=distutils.get_rank(),
+                    self.config["optim"].get(
+                        "eval_batch_size", self.config["optim"]["batch_size"]
+                    ),
                     shuffle=False,
                 )
-                self.test_loader = DataLoader(
+                self.test_loader = self.get_dataloader(
                     self.test_dataset,
-                    self.config["optim"].get("eval_batch_size", 64),
-                    collate_fn=self.parallel_collater,
-                    num_workers=self.config["optim"]["num_workers"],
-                    pin_memory=True,
-                    sampler=self.test_sampler,
+                    self.test_sampler,
                 )
 
         if "relax_dataset" in self.config["task"]:
@@ -181,20 +167,19 @@ class ForcesTrainer(BaseTrainer):
             self.relax_dataset = registry.get_dataset_class(
                 "single_point_lmdb"
             )(self.config["task"]["relax_dataset"])
-
-            self.relax_sampler = DistributedSampler(
+            self.relax_sampler = self.get_sampler(
                 self.relax_dataset,
-                num_replicas=distutils.get_world_size(),
-                rank=distutils.get_rank(),
+                self.config["optim"].get(
+                    "eval_batch_size", self.config["optim"]["batch_size"]
+                ),
                 shuffle=False,
             )
-            self.relax_loader = DataLoader(
+            self.relax_loader = self.get_dataloader(
                 self.relax_dataset,
-                batch_size=self.config["optim"].get("eval_batch_size", 64),
-                collate_fn=self.parallel_collater,
-                num_workers=self.config["optim"]["num_workers"],
-                pin_memory=True,
-                sampler=self.relax_sampler,
+                self.relax_sampler,
+                self.config["optim"].get(
+                    "eval_batch_size", self.config["optim"]["batch_size"]
+                ),
             )
 
         self.num_targets = 1
@@ -407,7 +392,6 @@ class ForcesTrainer(BaseTrainer):
             "primary_metric", self.evaluator.task_primary_metric[self.name]
         )
         self.best_val_metric = 1e9 if "mae" in primary_metric else -1.0
-        iters = 0
         self.metrics = {}
 
         # Calculate start_epoch from step instead of loading the epoch number
@@ -475,14 +459,16 @@ class ForcesTrainer(BaseTrainer):
                         split="train",
                     )
 
-                iters += 1
-                if checkpoint_every != -1 and iters % checkpoint_every == 0:
+                if (
+                    checkpoint_every != -1
+                    and self.step % checkpoint_every == 0
+                ):
                     self.save(
                         checkpoint_file="checkpoint.pt", training_state=True
                     )
 
                 # Evaluate on val set every `eval_every` iterations.
-                if iters % eval_every == 0:
+                if self.step % eval_every == 0:
                     if self.val_loader is not None:
                         val_metrics = self.validate(
                             split="val",
@@ -505,7 +491,7 @@ class ForcesTrainer(BaseTrainer):
                         self.save(self.epoch, self.step, self.metrics)
 
                 if self.scheduler.scheduler_type == "ReduceLROnPlateau":
-                    if iters % eval_every == 0:
+                    if self.step % eval_every == 0:
                         self.scheduler.step(
                             metrics=val_metrics[primary_metric]["metric"],
                         )


### PR DESCRIPTION
This PR implements a simple load balancing algorithm inside the batch sampler. The new `BalancedBatchSampler` either balances by number of atoms or by number of neighbors. Load balancing is activated by default (in atoms mode). Balancing relies on metadata stored alongside the lmdbs. If the `metadata.npz` file is not found, we print a warning. It is then deactivated per default. However, if the user explicitly specifies a load balancing mode it stays activated. We then load the data in the sampler to access its size, which incurs some overhead.

## Motivation
The size of a data sample can vary by up to an order of magnitude, which currently leads to skewed usage of both GPU memory and compute. In the worst case a GPU can draw an unlucky batch and run out of memory even 100k steps after training started.

For 16x8 GPUs with per-GPU batch size 4 (batch size 512 in total), this PR leads to a speed-up of around 3x and a memory reduction of more than 50%. For 8x8 GPUs with per-GPU batch size 32 (batch size 2048 in total), it leads to a speed-up of more than 20%.

## Considerations
The batch sampler runs in the main thread, not in a worker process. So this code is performance critical. Possible performance improvements:
- [x] numba for `balanced_partition` function: 100ms -> 0.5ms, no caching to prevent file system errors
- [x] add lmdbs only containing sizes (natoms and neighbors), so we don't have to load the data twice: 80ms -> 0.02ms
- use a different communication method, so the batch samplers don't push data to the GPU: 15ms, includes synchronization barrier (80ms before optimized loading). Probably not worth it.

Times measured using 16x8 GPUs with per-GPU batch size 4 (batch size 512 in total).

## Other changes
- We now set `eval_batch_size` to `batch_size` per default, instead of an arbitrary 64.
- Remove `args.num_workers`, since this is a duplicate of `config["optim"]["num_workers"]`
- add `numba` as a dependency
- Fix inconsistent validation intervals by using `self.step` instead of `iters`