### PR TITLE
Fix radius_graph_pbc's 1 unit cell assumption

### DIFF
--- a/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
+++ b/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
@@ -198,7 +198,7 @@ class TorchCalc:
 
     def update_graph(self, atoms):
         edge_index, cell_offsets, num_neighbors = radius_graph_pbc(
-            atoms, 6, 50, atoms.pos.device
+            atoms, 6, 50
         )
         atoms.edge_index = edge_index
         atoms.cell_offsets = cell_offsets

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -493,7 +493,8 @@ def get_pbc_distances(
     return out
 
 
-def radius_graph_pbc(data, radius, max_num_neighbors_threshold, device):
+def radius_graph_pbc(data, radius, max_num_neighbors_threshold):
+    device = data.pos.device
     batch_size = len(data.natoms)
 
     # position of the atoms

--- a/ocpmodels/models/cgcnn.py
+++ b/ocpmodels/models/cgcnn.py
@@ -116,7 +116,7 @@ class CGCNN(BaseModel):
 
         if self.otf_graph:
             edge_index, cell_offsets, neighbors = radius_graph_pbc(
-                data, self.cutoff, 50, data.pos.device
+                data, self.cutoff, 50
             )
             data.edge_index = edge_index
             data.cell_offsets = cell_offsets

--- a/ocpmodels/models/dimenet.py
+++ b/ocpmodels/models/dimenet.py
@@ -111,7 +111,7 @@ class DimeNetWrap(DimeNet):
 
         if self.otf_graph:
             edge_index, cell_offsets, neighbors = radius_graph_pbc(
-                data, self.cutoff, 50, data.pos.device
+                data, self.cutoff, 50
             )
             data.edge_index = edge_index
             data.cell_offsets = cell_offsets

--- a/ocpmodels/models/dimenet_plus_plus.py
+++ b/ocpmodels/models/dimenet_plus_plus.py
@@ -381,7 +381,7 @@ class DimeNetPlusPlusWrap(DimeNetPlusPlus):
 
         if self.otf_graph:
             edge_index, cell_offsets, neighbors = radius_graph_pbc(
-                data, self.cutoff, 50, data.pos.device
+                data, self.cutoff, 50
             )
             data.edge_index = edge_index
             data.cell_offsets = cell_offsets

--- a/ocpmodels/models/forcenet.py
+++ b/ocpmodels/models/forcenet.py
@@ -436,7 +436,7 @@ class ForceNet(BaseModel):
 
         if self.otf_graph:
             edge_index, cell_offsets, neighbors = radius_graph_pbc(
-                data, self.cutoff, 50, data.pos.device
+                data, self.cutoff, 50
             )
             data.edge_index = edge_index
             data.cell_offsets = cell_offsets

--- a/ocpmodels/models/schnet.py
+++ b/ocpmodels/models/schnet.py
@@ -91,7 +91,7 @@ class SchNetWrap(SchNet):
 
         if self.otf_graph:
             edge_index, cell_offsets, neighbors = radius_graph_pbc(
-                data, self.cutoff, 50, data.pos.device
+                data, self.cutoff, 50
             )
             data.edge_index = edge_index
             data.cell_offsets = cell_offsets

--- a/ocpmodels/models/spinconv.py
+++ b/ocpmodels/models/spinconv.py
@@ -196,7 +196,7 @@ class spinconv(BaseModel):
 
         if self.otf_graph:
             edge_index, cell_offsets, neighbors = radius_graph_pbc(
-                data, self.cutoff, 100, data.pos.device
+                data, self.cutoff, 100
             )
             data.edge_index = edge_index
             data.cell_offsets = cell_offsets
@@ -1048,8 +1048,8 @@ class SpinConvBlock(torch.nn.Module):
             self.wigner = []
             for xrot, yrot, zrot in zip(rotx, roty, rotz):
                 _blocks = []
-                for l in range(self.lmax + 1):
-                    _blocks.append(o3.wigner_D(l, xrot, yrot, zrot))
+                for l_degree in range(self.lmax + 1):
+                    _blocks.append(o3.wigner_D(l_degree, xrot, yrot, zrot))
                 self.wigner.append(torch.block_diag(*_blocks))
 
         if self.sphere_message == "fullconv":


### PR DESCRIPTION
`radius_graph_pbc` only considered the next unit cells for detecting neighbors. This PR lifts this limitation, making the function work for arbitrarily large cutoffs. To do so, we now calculate the number of required unit cells by looking at the closest distance between two cells.

## Other changes
- Remove the `device` argument and obtain it from the passed data.
- Refactored parts of `radius_graph_pbc` for elegance and efficiency
- Split out `get_max_neighbors_mask`, useful for handling neighbors