### PR TITLE
Correctly calculate distributed loss average

### DIFF
--- a/ocpmodels/modules/loss.py
+++ b/ocpmodels/modules/loss.py
@@ -1,6 +1,8 @@
 import torch
 from torch import nn
 
+from ocpmodels.common import distutils
+
 
 class L2MAELoss(nn.Module):
     def __init__(self, reduction="mean"):
@@ -14,3 +16,25 @@ class L2MAELoss(nn.Module):
             return torch.mean(dists)
         elif self.reduction == "sum":
             return torch.sum(dists)
+
+
+class DDPLoss(nn.Module):
+    def __init__(self, loss_fn, reduction="mean"):
+        super().__init__()
+        self.loss_fn = loss_fn
+        self.loss_fn.reduction = "sum"
+        self.reduction = reduction
+        assert reduction in ["mean", "sum"]
+
+    def forward(self, input: torch.Tensor, target: torch.Tensor):
+        loss = self.loss_fn(input, target)
+        if self.reduction == "mean":
+            num_samples = input.shape[0]
+            num_samples = distutils.all_reduce(
+                num_samples, device=input.device
+            )
+            # Multiply by world size since gradients are averaged
+            # across DDP replicas
+            return loss * distutils.get_world_size() / num_samples
+        else:
+            return loss

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -39,7 +39,7 @@ from ocpmodels.modules.evaluator import Evaluator
 from ocpmodels.modules.exponential_moving_average import (
     ExponentialMovingAverage,
 )
-from ocpmodels.modules.loss import L2MAELoss
+from ocpmodels.modules.loss import DDPLoss, L2MAELoss
 from ocpmodels.modules.normalizer import Normalizer
 from ocpmodels.modules.scheduler import LRScheduler
 
@@ -330,6 +330,8 @@ class BaseTrainer(ABC):
                 raise NotImplementedError(
                     f"Unknown loss function name: {loss_name}"
                 )
+            if distutils.initialized():
+                self.loss_fn[loss] = DDPLoss(self.loss_fn[loss])
 
     def load_optimizer(self):
         optimizer = self.config["optim"].get("optimizer", "AdamW")


### PR DESCRIPTION
We previously first calculated the loss average per DDP replica and then averaged across replicas. This leads to wrong results since not every replica has the same number of atoms or even systems. This PR changes the computation to instead calculate an average over all replicas by aggregating the number of samples.

This seems to give a tiny improvement in MAE (0.5% or so). But training looks very similar to previously.