### PR TITLE
Combined loss functions

### DIFF
--- a/ocpmodels/modules/loss.py
+++ b/ocpmodels/modules/loss.py
@@ -40,13 +40,14 @@ class NormL2MAELoss(nn.Module):
 
 
 class CosineLoss(nn.Module):
-    def __init__(self, reduction="mean"):
+    def __init__(self, reduction="mean", eps=1e-6):
         super().__init__()
         self.reduction = reduction
         assert reduction in ["mean", "sum"]
+        self.eps = eps
 
     def forward(self, input: torch.Tensor, target: torch.Tensor):
-        neg_cos = -torch.cosine_similarity(input, target)
+        neg_cos = -torch.cosine_similarity(input, target, eps=self.eps)
         if self.reduction == "mean":
             return torch.mean(neg_cos)
         elif self.reduction == "sum":

--- a/ocpmodels/modules/loss.py
+++ b/ocpmodels/modules/loss.py
@@ -74,8 +74,8 @@ class CombinedLoss(nn.Module):
     def forward(self, input: torch.Tensor, target: torch.Tensor):
         return sum(
             [
-                w * loss(input, target)
-                for w, loss in zip(self.weights, self.loss_fns)
+                weight * loss_fn(input, target)
+                for weight, loss_fn in zip(self.weights, self.loss_fns)
             ]
         )
 

--- a/ocpmodels/modules/loss.py
+++ b/ocpmodels/modules/loss.py
@@ -72,22 +72,24 @@ class CombinedLoss(nn.Module):
             loss_fn.reduction = reduction
 
     def forward(self, input: torch.Tensor, target: torch.Tensor):
-        loss = self.weights[0] * self.loss_fns[0](input, target)
-        for i in range(1, len(self.loss_fns)):
-            loss += self.weights[i] * self.loss_fns[i](input, target)
-        return loss
+        return sum(
+            [
+                w * loss(input, target)
+                for w, loss in zip(self.weights, self.loss_fns)
+            ]
+        )
 
 
-def get_loss(loss_name):
+def get_loss(loss_name, loss_kwargs):
     if loss_name in ["l1", "mae"]:
-        return nn.L1Loss()
+        return nn.L1Loss(**loss_kwargs)
     elif loss_name == "mse":
-        return nn.MSELoss()
+        return nn.MSELoss(**loss_kwargs)
     elif loss_name == "l2mae":
-        return L2MAELoss()
+        return L2MAELoss(**loss_kwargs)
     elif loss_name == "norml2mae":
-        return NormL2MAELoss()
+        return NormL2MAELoss(**loss_kwargs)
     elif loss_name == "cos":
-        return CosineLoss()
+        return CosineLoss(**loss_kwargs)
     else:
         raise NotImplementedError(f"Unknown loss function name: {loss_name}")

--- a/ocpmodels/modules/loss.py
+++ b/ocpmodels/modules/loss.py
@@ -16,6 +16,20 @@ class L2MAELoss(nn.Module):
             return torch.sum(dists)
 
 
+class CosineLoss(nn.Module):
+    def __init__(self, reduction="mean"):
+        super().__init__()
+        self.reduction = reduction
+        assert reduction in ["mean", "sum"]
+
+    def forward(self, input: torch.Tensor, target: torch.Tensor):
+        neg_cos = -torch.cosine_similarity(input, target)
+        if self.reduction == "mean":
+            return torch.mean(neg_cos)
+        elif self.reduction == "sum":
+            return torch.sum(neg_cos)
+
+
 class CombinedLoss(nn.Module):
     def __init__(self, loss_fns, weights=None):
         super().__init__()
@@ -48,5 +62,7 @@ def get_loss(loss_name):
         return nn.MSELoss()
     elif loss_name == "l2mae":
         return L2MAELoss()
+    elif loss_name == "cos":
+        return CosineLoss()
     else:
         raise NotImplementedError(f"Unknown loss function name: {loss_name}")


### PR DESCRIPTION
This PR adds support for more complex loss functions, as well as weighted combinations of loss functions.

Example of a new loss config:
```yaml
  loss_force:
  - name: l2mae
    weight: 0.5
  - name: norml2mae
    weight: 0.5
    min_norm: 1.e-3
```

Simple strings specifying only the loss name are still supported.

It might be nice to log the individual loss components along with the overall loss. I'm not sure how to implement this elegantly, though. Suggestions?