### PR TITLE
Makes Ray Tune optional and fixes submitit checkpointing bug

### DIFF
--- a/env.common.yml
+++ b/env.common.yml
@@ -21,7 +21,6 @@ dependencies:
   - pip:
     - demjson
     - Pillow
-    - ray[tune]==1.1.0
     - git+https://github.com/rusty1s/pytorch_geometric.git@4ea63d3
     - wandb
     - lmdb==1.1.1

--- a/ocpmodels/common/hpo_utils.py
+++ b/ocpmodels/common/hpo_utils.py
@@ -1,0 +1,55 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+import math
+
+from ray import tune
+
+
+def tune_reporter(
+    iters,
+    train_metrics,
+    val_metrics,
+    test_metrics=None,
+    metric_to_opt="val_loss",
+    min_max="min",
+):
+    """
+    Wrapper function for tune.report()
+
+    Args:
+        iters(dict): dict with training iteration info (e.g. steps, epochs)
+        train_metrics(dict): train metrics dict
+        val_metrics(dict): val metrics dict
+        test_metrics(dict, optional): test metrics dict, default is None
+        metric_to_opt(str, optional): str for val metric to optimize, default is val_loss
+        min_max(str, optional): either "min" or "max", determines whether metric_to_opt is to be minimized or maximized, default is min
+
+    """
+    # labels metric dicts
+    train = label_metric_dict(train_metrics, "train")
+    val = label_metric_dict(val_metrics, "val")
+    # this enables tolerance for NaNs assumes val set is used for optimization
+    if math.isnan(val[metric_to_opt]):
+        if min_max == "min":
+            val[metric_to_opt] = 100000.0
+        if min_max == "max":
+            val[metric_to_opt] = 0.0
+    if test_metrics:
+        test = label_metric_dict(test_metrics, "test")
+    else:
+        test = {}
+    # report results to Ray Tune
+    tune.report(**iters, **train, **val, **test)
+
+
+def label_metric_dict(metric_dict, split):
+    new_dict = {}
+    for key in metric_dict:
+        new_dict["{}_{}".format(split, key)] = metric_dict[key]
+    metric_dict = new_dict
+    return metric_dict

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -27,7 +27,6 @@ import torch
 import yaml
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from matplotlib.figure import Figure
-from ray import tune
 from torch_geometric.utils import remove_self_loops
 
 
@@ -770,48 +769,3 @@ def setup_logging():
         handler_err.setLevel(logging.WARNING)
         handler_err.setFormatter(log_formatter)
         root.addHandler(handler_err)
-
-
-def tune_reporter(
-    iters,
-    train_metrics,
-    val_metrics,
-    test_metrics=None,
-    metric_to_opt="val_loss",
-    min_max="min",
-):
-    """
-    Wrapper function for tune.report()
-
-    Args:
-        iters(dict): dict with training iteration info (e.g. steps, epochs)
-        train_metrics(dict): train metrics dict
-        val_metrics(dict): val metrics dict
-        test_metrics(dict, optional): test metrics dict, default is None
-        metric_to_opt(str, optional): str for val metric to optimize, default is val_loss
-        min_max(str, optional): either "min" or "max", determines whether metric_to_opt is to be minimized or maximized, default is min
-
-    """
-    # labels metric dicts
-    train = label_metric_dict(train_metrics, "train")
-    val = label_metric_dict(val_metrics, "val")
-    # this enables tolerance for NaNs assumes val set is used for optimization
-    if math.isnan(val[metric_to_opt]):
-        if min_max == "min":
-            val[metric_to_opt] = 100000.0
-        if min_max == "max":
-            val[metric_to_opt] = 0.0
-    if test_metrics:
-        test = label_metric_dict(test_metrics, "test")
-    else:
-        test = {}
-    # report results to Ray Tune
-    tune.report(**iters, **train, **val, **test)
-
-
-def label_metric_dict(metric_dict, split):
-    new_dict = {}
-    for key in metric_dict:
-        new_dict["{}_{}".format(split, key)] = metric_dict[key]
-    metric_dict = new_dict
-    return metric_dict

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -20,7 +20,6 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import yaml
-from ray import tune
 from torch.nn.parallel.distributed import DistributedDataParallel
 from tqdm import tqdm
 
@@ -32,7 +31,6 @@ from ocpmodels.common.utils import (
     build_config,
     plot_histogram,
     save_checkpoint,
-    tune_reporter,
     warmup_lr_lambda,
 )
 from ocpmodels.modules.evaluator import Evaluator
@@ -179,6 +177,11 @@ class BaseTrainer(ABC):
         self.is_hpo = is_hpo
 
         if self.is_hpo:
+            # conditional import is necessary for checkpointing
+            from ray import tune
+
+            from ocpmodels.common.hpo_utils import tune_reporter
+
             # sets the hpo checkpoint frequency
             # default is no checkpointing
             self.hpo_checkpoint_every = self.config["optim"].get(

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -443,7 +443,9 @@ class BaseTrainer(ABC):
         # checkpointing frequency can be adjusted by setting checkpoint_every in steps
         # to checkpoint every time results are communicated to Ray Tune set checkpoint_every=1
         if checkpoint_every != -1 and step % checkpoint_every == 0:
-            with tune.checkpoint_dir(step=step) as checkpoint_dir:
+            with tune.checkpoint_dir(  # noqa: F821
+                step=step
+            ) as checkpoint_dir:
                 path = os.path.join(checkpoint_dir, "checkpoint")
                 torch.save(self.save_state(epoch, step, metrics), path)
 
@@ -464,7 +466,7 @@ class BaseTrainer(ABC):
             self.hpo_checkpoint_every,
         )
         # report metrics to tune
-        tune_reporter(
+        tune_reporter(  # noqa: F821
             iters=progress,
             train_metrics={
                 k: train_metrics[k]["metric"] for k in self.metrics

--- a/scripts/hpo/README.md
+++ b/scripts/hpo/README.md
@@ -1,5 +1,8 @@
 # Running Hyperparameter Optimization with Ray Tune
 
+# Installation
+`pip install ray ray[tune]`
+
 ## Model config considerations
 
 The current Ray Tune implementation uses the standard OCP config. However, there are a number of config settings that require additional consideration.


### PR DESCRIPTION
This PR makes Ray Tune an optional dependency and fixes the checkpointing bug caused by importing Ray (only an issue for those using submitit). More details on the checkpointing bug can be found [here](https://github.com/ray-project/ray/issues/17745). 
 

