### PR TITLE
Recommended flake8 config for black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,12 @@ repos:
     rev: v2.3.0
     hooks:
     - id: flake8
+      args: ["--max-line-length", "88", "--select", "C,E,F,W,B,B950", "--extend-ignore", "E203,E501"]
     - id: trailing-whitespace
     - id: check-added-large-files
     - id: end-of-file-fixer
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.9.1
     hooks:
-    -   id: isort
-        args: ["--profile", "black", "--filter-files"]
+    - id: isort
+      args: ["--profile", "black", "--filter-files"]


### PR DESCRIPTION
black's line length mysteriously changed from 79 to 88 during the recent v0.0.3 update. This makes this more official by using the [flake8 settings recommended by black](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length).