### PR TITLE
bugfix: update model name in gemnet fit_scaling

### DIFF
--- a/ocpmodels/models/gemnet/fit_scaling.py
+++ b/ocpmodels/models/gemnet/fit_scaling.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     parser = flags.get_parser()
     args, override_args = parser.parse_known_args()
     config = build_config(args, override_args)
-    assert config["model"]["name"] == "gemnet"
+    assert config["model"]["name"].startswith("gemnet")
     config["logger"] = "tensorboard"
 
     if args.distributed:


### PR DESCRIPTION
The model name in gemnet fit_scaling.py needed to be updated to reflect the different variants i.e. `gemnet_t`. Also, when I ran black on the file is switched the order of imports — not sure if people are using different versions of black but I did not push the changes to imports.  