### PR TITLE
Reduce test_cosine_similarity check to 2 decimals

### DIFF
--- a/tests/evaluator/test_evaluator.py
+++ b/tests/evaluator/test_evaluator.py
@@ -70,7 +70,7 @@ class TestMetrics:
     def test_cosine_similarity(self):
         v1, v2 = torch.randn(1000000, 3), torch.randn(1000000, 3)
         res = cosine_similarity(v1, v2)
-        np.testing.assert_almost_equal(res["metric"], 0, decimal=3)
+        np.testing.assert_almost_equal(res["metric"], 0, decimal=2)
         np.testing.assert_almost_equal(
             res["total"] / res["numel"], res["metric"]
         )


### PR DESCRIPTION
This test can fail randomly since the difference is sometimes too large.