### PR TITLE
Load balancing metadata script

### DIFF
--- a/TRAIN.md
+++ b/TRAIN.md
@@ -24,6 +24,17 @@ python -u -m torch.distributed.launch --nproc_per_node=8 main.py --distributed -
 `torch.distributed.launch` launches multiple processes for distributed training. For more details, refer to
 https://pytorch.org/docs/stable/distributed.html#launch-utility
 
+If training with multiple GPUs, GPU load balancing may be used to evenly distribute a batch of variable system sizes across GPUs. Load balancing may either balance by number of atoms or number of neighbors. A `metadata.npz` file must be available in the dataset directory to take advantage of this feature. The following command will generate a  `metadata.npz` file and place it in the corresponding directory. 
+```
+python scripts/make_lmdb_sizes.py --data-path data/s2ef/train/2M --num-workers 8
+```
+Load balancing is activated by default (in atoms mode). To change modes you can specify the following in your config:
+```
+optim:
+  load_balancing: neighbors
+```
+For more details, refer to https://github.com/Open-Catalyst-Project/ocp/pull/267.
+
 If you have access to a slurm cluster, we use the [submitit](https://github.com/facebookincubator/submitit) package to simplify multi-node distributed training:
 ```
 python main.py --distributed --num-gpus 8 --num-nodes 6 --submit [...]

--- a/scripts/make_lmdb_sizes.py
+++ b/scripts/make_lmdb_sizes.py
@@ -1,0 +1,75 @@
+"""
+This script provides the functionality to generate metadata.npz files necessary
+for load_balancing the DataLoader.
+
+"""
+from ocpmodels.datasets import TrajectoryLmdbDataset, SinglePointLmdbDataset
+from tqdm import tqdm
+import os
+import numpy as np
+import argparse
+import warnings
+import multiprocessing as mp
+
+def get_data(index):
+    data = dataset[index]
+    natoms = data.natoms
+    neighbors = None
+    if hasattr(data, "edge_index"):
+        neighbors = data.edge_index.shape[1]
+
+    return index, natoms, neighbors
+
+def main(args):
+    path = args.data_path
+    global dataset
+    if os.path.isdir(path):
+        dataset = TrajectoryLmdbDataset({"src": path})
+        outpath = os.path.join(path, "metadata.npz")
+    elif os.path.isfile(path):
+        dataset = SinglePointLmdbDataset({"src": path})
+        outpath = os.path.join(
+            os.path.dirname(path),
+            "metadata.npz"
+        )
+
+    indices = range(len(dataset))
+
+    pool = mp.Pool(args.num_workers)
+    outputs = list(tqdm(pool.imap(get_data, indices), total=len(indices)))
+
+    indices = []
+    natoms = []
+    neighbors = []
+    for i in outputs:
+        indices.append(i[0])
+        natoms.append(i[1])
+        neighbors.append(i[2])
+
+    _sort = np.argsort(indices)
+    sorted_natoms = np.array(natoms, dtype=np.int32)[_sort]
+    if None in neighbors:
+        warnings.warn(
+            f"edge_index information not found, {outpath} only supports atom-wise load balancing."
+        )
+        np.savez(outpath, natoms=sorted_natoms)
+    else:
+        sorted_neighbors = np.array(neighbors, dtype=np.int32)[_sort]
+        np.savez(outpath, natoms=sorted_natoms, neighbors=sorted_neighbors)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--data-path",
+        required=True,
+        type=str,
+        help="Path to S2EF directory or IS2R* .lmdb file",
+    )
+    parser.add_argument(
+        "--num-workers",
+        default=1,
+        type=int,
+        help="Num of workers to parallelize across",
+    )
+    args = parser.parse_args()
+    main(args)

--- a/scripts/make_lmdb_sizes.py
+++ b/scripts/make_lmdb_sizes.py
@@ -3,13 +3,16 @@ This script provides the functionality to generate metadata.npz files necessary
 for load_balancing the DataLoader.
 
 """
-from ocpmodels.datasets import TrajectoryLmdbDataset, SinglePointLmdbDataset
-from tqdm import tqdm
-import os
-import numpy as np
 import argparse
-import warnings
 import multiprocessing as mp
+import os
+import warnings
+
+import numpy as np
+from tqdm import tqdm
+
+from ocpmodels.datasets import SinglePointLmdbDataset, TrajectoryLmdbDataset
+
 
 def get_data(index):
     data = dataset[index]
@@ -20,6 +23,7 @@ def get_data(index):
 
     return index, natoms, neighbors
 
+
 def main(args):
     path = args.data_path
     global dataset
@@ -28,10 +32,7 @@ def main(args):
         outpath = os.path.join(path, "metadata.npz")
     elif os.path.isfile(path):
         dataset = SinglePointLmdbDataset({"src": path})
-        outpath = os.path.join(
-            os.path.dirname(path),
-            "metadata.npz"
-        )
+        outpath = os.path.join(os.path.dirname(path), "metadata.npz")
 
     indices = range(len(dataset))
 
@@ -56,6 +57,7 @@ def main(args):
     else:
         sorted_neighbors = np.array(neighbors, dtype=np.int32)[_sort]
         np.savez(outpath, natoms=sorted_natoms, neighbors=sorted_neighbors)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Provides the script necessary to generate the `metadata.npz` needed for GPU load balancing (#267). 

S2EF sample - 
```
python make_lmdb_sizes.py --data-path path/to/s2ef/all/directory/--num-workers 8
```
IS2RE sample - 
```
python make_lmdb_sizes.py --data-path path/to/is2re/all/data.lmdb--num-workers 8
```
Compatible with both IS2RE and S2EF datasets. While IS2RE metadata files will be uploaded in a future PR, support is provided for both for people interested in using this for alternative datasets.