### PR TITLE
explicit cpu map

### DIFF
--- a/ocpmodels/common/relaxation/ase_utils.py
+++ b/ocpmodels/common/relaxation/ase_utils.py
@@ -105,6 +105,7 @@ class OCPCalculator(Calculator):
             slurm=config.get("slurm", {}),
             local_rank=config.get("local_rank", 0),
             is_debug=config.get("is_debug", True),
+            cpu=True,
         )
 
         if checkpoint is not None:


### PR DESCRIPTION
Not explicitly mapping to `cpu` causes issues when loading checkpoints with GPU tensors. This ASE calculator isn't meant to be compatible with GPUs so CPU hardcoding is fine. 