### PR TITLE
Fix shared parameter gradient scaling

### DIFF
--- a/ocpmodels/models/gemnet/gemnet.py
+++ b/ocpmodels/models/gemnet/gemnet.py
@@ -23,9 +23,7 @@ from .layers.atom_update_block import OutputBlock
 from .layers.base_layers import Dense
 from .layers.efficient import EfficientInteractionDownProjection
 from .layers.embedding_block import AtomEmbedding, EdgeEmbedding
-from .layers.interaction_block import (
-    InteractionBlockTripletsOnly,
-)
+from .layers.interaction_block import InteractionBlockTripletsOnly
 from .layers.radial_basis import RadialBasis
 from .layers.scaling import AutomaticFit
 from .layers.spherical_basis import CircularBasisLayer
@@ -252,10 +250,10 @@ class GemNetT(torch.nn.Module):
         self.int_blocks = torch.nn.ModuleList(int_blocks)
 
         self.shared_parameters = [
-            (self.mlp_rbf3, self.num_blocks),
-            (self.mlp_cbf3, self.num_blocks),
-            (self.mlp_rbf_h, self.num_blocks),
-            (self.mlp_rbf_out, self.num_blocks + 1),
+            (self.mlp_rbf3.linear.weight, self.num_blocks),
+            (self.mlp_cbf3.weight, self.num_blocks),
+            (self.mlp_rbf_h.linear.weight, self.num_blocks),
+            (self.mlp_rbf_out.linear.weight, self.num_blocks + 1),
         ]
 
     def get_triplets(self, edge_index, num_atoms):

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -597,6 +597,14 @@ class BaseTrainer(ABC):
             for p, factor in self.model.module.shared_parameters:
                 if hasattr(p, "grad") and p.grad is not None:
                     p.grad.detach().div_(factor)
+                else:
+                    if not hasattr(self, "warned_shared_param_no_grad"):
+                        self.warned_shared_param_no_grad = True
+                        logging.warning(
+                            "Some shared parameters do not have a gradient. "
+                            "Please check if all shared parameters are used "
+                            "and point to PyTorch parameters."
+                        )
         if self.clip_grad_norm:
             if self.scaler:
                 self.scaler.unscale_(self.optimizer)

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -593,9 +593,9 @@ class BaseTrainer(ABC):
         self.optimizer.zero_grad()
         loss.backward()
         # Scale down the gradients of shared parameters
-        if hasattr(self.model, "shared_parameters"):
-            for p, factor in self.model.shared_parameters:
-                if p.grad is not None:
+        if hasattr(self.model.module, "shared_parameters"):
+            for p, factor in self.model.module.shared_parameters:
+                if hasattr(p, "grad") and p.grad is not None:
                     p.grad.detach().div_(factor)
         if self.clip_grad_norm:
             if self.scaler:


### PR DESCRIPTION
Gradient scaling for shared parameters didn't work previous since it used `trainer.model` instead of `trainer.model.module`. Also, GemNet-T passed modules instead of parameters. This fixes these two issues.

Additionally, we now also show a warning if a shared parameter has no gradient, which usually means that it doesn't point to a PyTorch parameter.