### PR TITLE
missing spinconv device definition

### DIFF
--- a/ocpmodels/models/spinconv.py
+++ b/ocpmodels/models/spinconv.py
@@ -566,9 +566,9 @@ class spinconv(BaseModel):
         return edge_index, edge_distance, edge_distance_vec
 
     def _random_rot_mat(self, num_matrices, device):
-        ang_a = 2.0 * math.pi * torch.rand(num_matrices)
-        ang_b = 2.0 * math.pi * torch.rand(num_matrices)
-        ang_c = 2.0 * math.pi * torch.rand(num_matrices)
+        ang_a = 2.0 * math.pi * torch.rand(num_matrices, device=device)
+        ang_b = 2.0 * math.pi * torch.rand(num_matrices, device=device)
+        ang_c = 2.0 * math.pi * torch.rand(num_matrices, device=device)
 
         cos_a = torch.cos(ang_a)
         cos_b = torch.cos(ang_b)


### PR DESCRIPTION
Running spinconv outside the trainers runs into `Floating point exception (core dumped)` errors during the model forward pass. This PR resolves that issue by explicitly defining the device to be used in the output block. 