### PR TITLE
Fix radius_graph_pbc for atoms outside center

### DIFF
--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -493,26 +493,21 @@ def get_pbc_distances(
     return out
 
 
-def radius_graph_pbc(
-    data, radius, max_num_neighbors_threshold, centering_iterations=3
-):
+def radius_graph_pbc(data, radius, max_num_neighbors_threshold):
     device = data.pos.device
     batch_size = len(data.natoms)
 
-    # Move all atoms into central unit cell
-    # Move by one unit vector after another to prevent interactions.
-    # The matrix inverse used by pymatgen does not guarantee that all atoms
-    #  are in the central unit cells when the unit vectors are not orthogonal.
-    atom_pos = data.pos
-    atom_cell = data.cell[data.batch]
-    cell_norm = torch.sum(atom_cell * atom_cell, dim=-1)
-    atom_offset = data.cell_offsets.new_zeros(atom_pos.shape)
-    for _ in range(centering_iterations):
-        for i in range(3):
-            dot_prod = torch.sum(atom_pos * atom_cell[:, i], dim=-1)
-            offset_step = (dot_prod / cell_norm[:, i]).floor()
-            atom_offset[:, i] += offset_step.long()
-            atom_pos = atom_pos - offset_step[:, None] * atom_cell[:, i]
+    # Move all atoms into center
+    mean_pos = segment_coo(
+        data.pos, data.batch, dim_size=batch_size, reduce="mean"
+    )
+    atom_pos = data.pos - mean_pos[data.batch]
+    inv_cell = torch.linalg.inv(data.cell)
+    frac_pos = atom_pos[:, None, :] @ inv_cell[data.batch]
+    frac_pos_center = frac_pos % 1
+    atom_pos = frac_pos_center @ data.cell[data.batch]
+    atom_pos = atom_pos.squeeze(1)
+    atom_offset = frac_pos.squeeze(1).floor().long()
 
     # Before computing the pairwise distances between atoms, first create a list of atom indices to compare for the entire batch
     num_atoms_per_image = data.natoms


### PR DESCRIPTION
Some atoms in the data are currently not in the central unit cell, but offset by a unit vector. This PR moves all atoms to the center in `radius_graph_pbc` to ensure that we correctly obtain all neighbors in these cases.