### PR TITLE
bugfix loading best_checkpoint.pt

### DIFF
--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -342,6 +342,8 @@ class BaseTrainer(ABC):
             self.scheduler.scheduler.load_state_dict(checkpoint["scheduler"])
         if "ema" in checkpoint and checkpoint["ema"] is not None:
             self.ema.load_state_dict(checkpoint["ema"])
+        else:
+            self.ema = None
 
         for key in checkpoint["normalizers"]:
             if key in self.normalizers:


### PR DESCRIPTION
Resolves bug when trying to use `best_checkpoint.pt` to make predictions. Since `ema`  is present in the config but `checkpoint["ema"]` is not, the model ends up loading random EMA weights.