### PR TITLE
bugfix: checkpoint with no val set Ref. #290

### DIFF
--- a/ocpmodels/trainers/energy_trainer.py
+++ b/ocpmodels/trainers/energy_trainer.py
@@ -350,9 +350,6 @@ class EnergyTrainer(BaseTrainer):
                                 val_metrics,
                             )
 
-                    else:
-                        self.save(self.epoch, self.step, self.metrics)
-
                 if self.scheduler.scheduler_type == "ReduceLROnPlateau":
                     if self.step % eval_every == 0:
                         self.scheduler.step(

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -484,9 +484,6 @@ class ForcesTrainer(BaseTrainer):
                                 val_metrics,
                             )
 
-                    else:
-                        self.save(self.epoch, self.step, self.metrics)
-
                 if self.scheduler.scheduler_type == "ReduceLROnPlateau":
                     if self.step % eval_every == 0:
                         self.scheduler.step(


### PR DESCRIPTION
Resolves #290 This PR removes obsolete lines for checkpointing. The following lines already cover the case where no validation is defined:

`forces_trainer`: https://github.com/Open-Catalyst-Project/ocp/blob/f34a0af36671442754c833c21b857f4c307437b7/ocpmodels/trainers/forces_trainer.py#L459-L465

`energy_trainer`: https://github.com/Open-Catalyst-Project/ocp/blob/f34a0af36671442754c833c21b857f4c307437b7/ocpmodels/trainers/energy_trainer.py#L315-L317

In both trainers `eval_every` will control how often a checkpoint gets saved out.