### PR TITLE
Not load data when using OCPCalculator

### DIFF
--- a/ocpmodels/common/relaxation/ase_utils.py
+++ b/ocpmodels/common/relaxation/ase_utils.py
@@ -106,6 +106,7 @@ class OCPCalculator(Calculator):
             local_rank=config.get("local_rank", 0),
             is_debug=config.get("is_debug", True),
             cpu=True,
+            ocp_calc=True,
         )
 
         if checkpoint is not None:

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -68,12 +68,13 @@ class BaseTrainer(ABC):
         cpu=False,
         name="base_trainer",
         slurm={},
+        ocp_calc=False,
     ):
         self.name = name
         self.cpu = cpu
         self.epoch = 0
         self.step = 0
-
+        self.ocp_calc = ocp_calc
         if torch.cuda.is_available() and not self.cpu:
             self.device = torch.device(f"cuda:{local_rank}")
         else:

--- a/ocpmodels/trainers/energy_trainer.py
+++ b/ocpmodels/trainers/energy_trainer.py
@@ -79,6 +79,7 @@ class EnergyTrainer(BaseTrainer):
         local_rank=0,
         amp=False,
         cpu=False,
+        ocp_calc=False,
         slurm={},
     ):
         super().__init__(
@@ -100,6 +101,7 @@ class EnergyTrainer(BaseTrainer):
             amp=amp,
             cpu=cpu,
             name="is2re",
+            ocp_calc=False,
             slurm=slurm,
         )
 
@@ -118,7 +120,7 @@ class EnergyTrainer(BaseTrainer):
         self.val_loader = self.test_loader = self.train_loader = None
         self.val_sampler = self.test_sampler = self.train_sampler = None
 
-        if self.config.get("dataset", None):
+        if self.config.get("dataset", None) and not self.ocp_calc:
             self.train_dataset = registry.get_dataset_class(
                 self.config["task"]["dataset"]
             )(self.config["dataset"])
@@ -132,7 +134,7 @@ class EnergyTrainer(BaseTrainer):
                 self.train_sampler,
             )
 
-        if self.config.get("val_dataset", None):
+        if self.config.get("val_dataset", None) and not self.ocp_calc:
             self.val_dataset = registry.get_dataset_class(
                 self.config["task"]["dataset"]
             )(self.config["val_dataset"])
@@ -147,7 +149,7 @@ class EnergyTrainer(BaseTrainer):
                 self.val_dataset,
                 self.val_sampler,
             )
-        if self.config.get("test_dataset", None):
+        if self.config.get("test_dataset", None) and not self.ocp_calc:
             self.test_dataset = registry.get_dataset_class(
                 self.config["task"]["dataset"]
             )(self.config["test_dataset"])

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -83,6 +83,7 @@ class ForcesTrainer(BaseTrainer):
         local_rank=0,
         amp=False,
         cpu=False,
+        ocp_calc=False,
         slurm={},
     ):
         super().__init__(
@@ -104,6 +105,7 @@ class ForcesTrainer(BaseTrainer):
             amp=amp,
             cpu=cpu,
             name="s2ef",
+            ocp_calc=ocp_calc,
             slurm=slurm,
         )
 
@@ -116,7 +118,7 @@ class ForcesTrainer(BaseTrainer):
         )
         if self.config["task"]["dataset"] == "trajectory_lmdb":
             self.train_loader = self.val_loader = self.test_loader = None
-            if self.config.get("dataset", None):
+            if self.config.get("dataset", None) and not self.ocp_calc:
                 self.train_dataset = registry.get_dataset_class(
                     self.config["task"]["dataset"]
                 )(self.config["dataset"])
@@ -130,7 +132,7 @@ class ForcesTrainer(BaseTrainer):
                     self.train_sampler,
                 )
 
-            if self.config.get("val_dataset", None):
+            if self.config.get("val_dataset", None) and not self.ocp_calc:
                 self.val_dataset = registry.get_dataset_class(
                     self.config["task"]["dataset"]
                 )(self.config["val_dataset"])
@@ -145,7 +147,7 @@ class ForcesTrainer(BaseTrainer):
                     self.val_dataset,
                     self.val_sampler,
                 )
-            if self.config.get("test_dataset", None):
+            if self.config.get("test_dataset", None) and not self.ocp_calc:
                 self.test_dataset = registry.get_dataset_class(
                     self.config["task"]["dataset"]
                 )(self.config["test_dataset"])
@@ -161,7 +163,7 @@ class ForcesTrainer(BaseTrainer):
                     self.test_sampler,
                 )
 
-        if "relax_dataset" in self.config["task"]:
+        if "relax_dataset" in self.config["task"] and not self.ocp_calc:
             assert os.path.isfile(self.config["task"]["relax_dataset"]["src"])
 
             self.relax_dataset = registry.get_dataset_class(


### PR DESCRIPTION
This PR adds a flag to not load data from config when OCPCalculator is used