### PR TITLE
Loads checkpoint cleanly for non DDP checkpoint and parallelized inference

### DIFF
--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -333,6 +333,10 @@ class BaseTrainer(ABC):
             # since Python 3.6 and officially ordered since Python 3.7
             new_dict = {k[7:]: v for k, v in checkpoint["state_dict"].items()}
             self.model.load_state_dict(new_dict)
+        elif distutils.initialized() and first_key.split(".")[1] != "module":
+            new_dict = {
+                f"module.{k}": v for k, v in checkpoint["state_dict"].items()
+            }
         else:
             self.model.load_state_dict(checkpoint["state_dict"])
 


### PR DESCRIPTION
This PR handles the case when the checkpoint loaded hasn't been trained with DDP but uses DDP for inference.