### PR TITLE
Speedup relaxations and support for resuming relaxations

### DIFF
--- a/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
+++ b/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
@@ -121,8 +121,8 @@ class LBFGS:
                 iteration, update_mask, f0, fmax
             )
             converged = torch.all(torch.logical_not(update_mask))
-            # GPU memory usage as per nvidia-smi seems to gradually build up as
-            # batches are processed. This releases unoccupied cached memory.
+        # GPU memory usage as per nvidia-smi seems to gradually build up as
+        # batches are processed. This releases unoccupied cached memory.
         torch.cuda.empty_cache()
 
         if trajectories is not None:

--- a/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
+++ b/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
@@ -95,7 +95,7 @@ class LBFGS:
         if self.traj_dir:
             self.traj_dir.mkdir(exist_ok=True, parents=True)
             trajectories = [
-                ase.io.Trajectory(self.traj_dir / f"{name}.traj", mode="a")
+                ase.io.Trajectory(self.traj_dir / f"{name}.traj_tmp", mode="w")
                 for name in self.traj_names
             ]
 
@@ -123,11 +123,14 @@ class LBFGS:
             converged = torch.all(torch.logical_not(update_mask))
             # GPU memory usage as per nvidia-smi seems to gradually build up as
             # batches are processed. This releases unoccupied cached memory.
-            torch.cuda.empty_cache()
+        torch.cuda.empty_cache()
 
         if trajectories is not None:
             for traj in trajectories:
                 traj.close()
+            for name in self.traj_names:
+                traj_fl = Path(self.traj_dir / f"{name}.traj_tmp", mode="w")
+                traj_fl.rename(traj_fl.with_suffix(".traj"))
 
         self.atoms.y, self.atoms.force = self.get_forces(
             apply_constraint=False

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -814,3 +814,11 @@ def setup_logging():
         handler_err.setLevel(logging.WARNING)
         handler_err.setFormatter(log_formatter)
         root.addHandler(handler_err)
+
+
+def check_traj_files(batch, traj_dir):
+    if traj_dir is None:
+        return False
+    traj_dir = Path(traj_dir)
+    traj_files = [traj_dir / f"{id}.traj" for id in batch[0].sid.tolist()]
+    return all(fl.exists() for fl in traj_files)


### PR DESCRIPTION
* We call `torch.cuda.empty_cache()` after each relaxation step which is causing a big slowdown in relaxations. Calling it only at the end of the relaxation gives a >5x speedup for 216 Gemnet-Q model, and >4x for the 39M model: [benchmarks](https://docs.google.com/spreadsheets/d/1iws5eT0ZdyyWsJALOdu11JyJbhP2plJkTuWO4cvZR1c/edit?usp=sharing)
* Support for resuming relaxations: If all the traj files for a batch already exist, we skip running the relaxation. Note that this does not compute the metrics correctly (This can be fixed in a later PR by reading the relaxed state from the traj files).
* Changed the traj file writing from `append` mode to `write` mode. Our data loader contains a few repeated examples, which causes multiple relaxation trajectories to be written to the same traj files. With this change, we only keep the final trajectory.
