### PR TITLE
no-pbc gemnet support

### DIFF
--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -816,6 +816,23 @@ def setup_logging():
         root.addHandler(handler_err)
 
 
+def compute_neighbors(data, edge_index):
+    # Get number of neighbors
+    # segment_coo assumes sorted index
+    ones = edge_index[1].new_ones(1).expand_as(edge_index[1])
+    num_neighbors = segment_coo(
+        ones, edge_index[1], dim_size=data.natoms.sum()
+    )
+
+    # Get number of neighbors per image
+    image_indptr = torch.zeros(
+        data.natoms.shape[0] + 1, device=data.pos.device, dtype=torch.long
+    )
+    image_indptr[1:] = torch.cumsum(data.natoms, dim=0)
+    neighbors = segment_csr(num_neighbors, image_indptr)
+    return neighbors
+
+
 def check_traj_files(batch, traj_dir):
     if traj_dir is None:
         return False

--- a/ocpmodels/models/gemnet/gemnet.py
+++ b/ocpmodels/models/gemnet/gemnet.py
@@ -9,11 +9,13 @@ from typing import Optional
 
 import numpy as np
 import torch
+from torch_geometric.nn import radius_graph
 from torch_scatter import scatter
 from torch_sparse import SparseTensor
 
 from ocpmodels.common.registry import registry
 from ocpmodels.common.utils import (
+    compute_neighbors,
     conditional_grad,
     get_pbc_distances,
     radius_graph_pbc,
@@ -127,6 +129,7 @@ class GemNetT(torch.nn.Module):
         cbf: dict = {"name": "spherical_harmonics"},
         extensive: bool = True,
         otf_graph: bool = False,
+        use_pbc: bool = True,
         output_init: str = "HeOrthogonal",
         activation: str = "swish",
         scale_file: Optional[str] = None,
@@ -145,6 +148,7 @@ class GemNetT(torch.nn.Module):
 
         self.regress_forces = regress_forces
         self.otf_graph = otf_graph
+        self.use_pbc = use_pbc
 
         AutomaticFit.reset()  # make sure that queue is empty (avoid potential error)
 
@@ -431,24 +435,38 @@ class GemNetT(torch.nn.Module):
             cell_offsets = data.cell_offsets
             neighbors = data.neighbors
 
-        # Switch the indices, so the second one becomes the target index,
-        # over which we can efficiently aggregate.
-        out = get_pbc_distances(
-            data.pos,
-            edge_index,
-            data.cell,
-            cell_offsets,
-            neighbors,
-            return_offsets=True,
-            return_distance_vec=True,
-        )
+        if self.use_pbc:
+            # Switch the indices, so the second one becomes the target index,
+            # over which we can efficiently aggregate.
+            out = get_pbc_distances(
+                data.pos,
+                edge_index,
+                data.cell,
+                cell_offsets,
+                neighbors,
+                return_offsets=True,
+                return_distance_vec=True,
+            )
 
-        edge_index = out["edge_index"]
-        D_st = out["distances"]
-        # These vectors actually point in the opposite direction.
-        # But we want to use col as idx_t for efficient aggregation.
-        V_st = -out["distance_vec"] / D_st[:, None]
-        # offsets_ca = -out["offsets"]  # a - c + offset
+            edge_index = out["edge_index"]
+            D_st = out["distances"]
+            # These vectors actually point in the opposite direction.
+            # But we want to use col as idx_t for efficient aggregation.
+            V_st = -out["distance_vec"] / D_st[:, None]
+            # offsets_ca = -out["offsets"]  # a - c + offset
+        else:
+            edge_index = radius_graph(
+                data.pos, r=self.cutoff, batch=data.batch
+            )
+            j, i = edge_index
+            distance_vec = data.pos[j] - data.pos[i]
+
+            D_st = distance_vec.norm(dim=-1)
+            V_st = -distance_vec / D_st[:, None]
+            cell_offsets = torch.zeros(
+                edge_index.shape[1], 3, device=data.pos.device
+            )
+            neighbors = compute_neighbors(data, edge_index)
 
         # Mask interaction edges if required
         if self.otf_graph or np.isclose(self.cutoff, 6):


### PR DESCRIPTION
GemNet currently hardcodes PBC graph calculation with no flag to offer an alternative like other models in the repo i.e.
https://github.com/Open-Catalyst-Project/ocp/blob/ae6cf263abd9a027291cc8c880d41932b4049517/ocpmodels/models/spinconv.py#L205-L228

Replicating MD17, COLL, QM9, and other no-pbc datasets is not possible unless the dataset is constructed with an extremely large unit cell. This PR adds the `use_pbc` flag to allow users to use `raidus_graph` instead of our `radius_graph_pbc` implementation.