### PR TITLE
Added support for PyTorch Geometric 2.0's updated Data format

### DIFF
--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -13,7 +13,6 @@ import importlib
 import itertools
 import json
 import logging
-import math
 import os
 import sys
 import time
@@ -21,14 +20,25 @@ from bisect import bisect
 from itertools import product
 from pathlib import Path
 
-import demjson
 import numpy as np
 import torch
+import torch_geometric
 import yaml
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from matplotlib.figure import Figure
+from torch_geometric.data import Data
 from torch_geometric.utils import remove_self_loops
 from torch_scatter import segment_coo, segment_csr
+
+
+def pyg2_data_transform(data: Data):
+    # if we're on the new pyg (2.0 or later), we need to convert the data to the new format
+    if torch_geometric.__version__ >= "2.0":
+        return Data(
+            **{k: v for k, v in data.__dict__.items() if v is not None}
+        )
+
+    return data
 
 
 def save_checkpoint(

--- a/ocpmodels/datasets/single_point_lmdb.py
+++ b/ocpmodels/datasets/single_point_lmdb.py
@@ -6,7 +6,6 @@ LICENSE file in the root directory of this source tree.
 """
 
 import errno
-import os
 import pickle
 from pathlib import Path
 
@@ -14,6 +13,7 @@ import lmdb
 from torch.utils.data import Dataset
 
 from ocpmodels.common.registry import registry
+from ocpmodels.common.utils import pyg2_data_transform
 
 
 @registry.register_dataset("single_point_lmdb")
@@ -53,7 +53,7 @@ class SinglePointLmdbDataset(Dataset):
     def __getitem__(self, idx):
         # Return features.
         datapoint_pickled = self.env.begin().get(self._keys[idx])
-        data_object = pickle.loads(datapoint_pickled)
+        data_object = pyg2_data_transform(pickle.loads(datapoint_pickled))
         data_object = (
             data_object
             if self.transform is None

--- a/ocpmodels/datasets/trajectory_lmdb.py
+++ b/ocpmodels/datasets/trajectory_lmdb.py
@@ -7,9 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 import bisect
 import logging
-import math
 import pickle
-import random
 from pathlib import Path
 
 import lmdb
@@ -18,8 +16,8 @@ import torch
 from torch.utils.data import Dataset
 from torch_geometric.data import Batch
 
-from ocpmodels.common import distutils
 from ocpmodels.common.registry import registry
+from ocpmodels.common.utils import pyg2_data_transform
 
 
 @registry.register_dataset("trajectory_lmdb")
@@ -75,7 +73,7 @@ class TrajectoryLmdbDataset(Dataset):
             .begin()
             .get(f"{self._keys[db_idx][el_idx]}".encode("ascii"))
         )
-        data_object = pickle.loads(datapoint_pickled)
+        data_object = pyg2_data_transform(pickle.loads(datapoint_pickled))
         if self.transform is not None:
             data_object = self.transform(data_object)
 


### PR DESCRIPTION
PyG >= 2.0 has an updated data format which causes our script to crash when running with PyG >= 2.0, due to the fact that our LMDBs store each data point as the bytes of the pickled PyG data object. 

This PR adds a simple function that converts the old (pickled) PyG < 2.0 `Data` objects to the new PyG >= 2.0 `Data` format if the current PyG version is >= 2.0.