### PR TITLE
remove ipynb from language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-documentation


### PR DESCRIPTION
Minor - per recent tutorial changes, repo stats report as majority jupyter notebooks which is misleading due to how things are saved there. This removes ipynb notebooks from those stats.