### PR TITLE
demjson env fix

### DIFF
--- a/env.common.yml
+++ b/env.common.yml
@@ -20,7 +20,6 @@ dependencies:
   - black
   - numba
   - pip:
-    - demjson
     - Pillow
     - git+https://github.com/rusty1s/pytorch_geometric.git@4ea63d3
     - wandb

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -21,7 +21,6 @@ from bisect import bisect
 from itertools import product
 from pathlib import Path
 
-import demjson
 import numpy as np
 import torch
 import yaml


### PR DESCRIPTION
Recent updates to `setuptools` breaks demjson - https://github.com/dmeranda/demjson/issues/40. Since demjson isn't used in the repo we can just remove it rather than downgrading setuptools.

Resolves #320 