### PR TITLE
decorator direct force bugfix

### DIFF
--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -114,7 +114,7 @@ def conditional_grad(dec):
     def decorator(func):
         def cls_method(self, *args, **kwargs):
             f = func
-            if self.regress_forces:
+            if self.regress_forces and not getattr(self, "direct_forces", 0):
                 f = dec(func)
             return f(self, *args, **kwargs)
 


### PR DESCRIPTION
The [decorator](https://github.com/Open-Catalyst-Project/ocp/blob/dadc0fd20681554178de65f8cf17aac446a81e30/ocpmodels/models/gemnet/gemnet.py#L526-L527) we wrap our models around to improve inference throughput (not storing gradients) is disabled if `self.regress_forces=True` since gradients need to be stored for energy gradients. However, in lieu of direct-force models this wrapper is triggered unnecessarily. This PR adds an additional check for `self.direct_forces` and enables it accordingly. All future direct force models should use `self.direct_forces` as well. 

For a variant of GemNet, I'm seeing a ~25% reduction in GPU memory usage, enabling larger batch sizes than currently used. 