### PR TITLE
Update `conditional_grad` decorator to use `functools.wraps` on the original function

### DIFF
--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -17,6 +17,7 @@ import os
 import sys
 import time
 from bisect import bisect
+from functools import wraps
 from itertools import product
 from pathlib import Path
 
@@ -112,6 +113,7 @@ def conditional_grad(dec):
     "Decorator to enable/disable grad depending on whether force/energy predictions are being made"
     # Adapted from https://stackoverflow.com/questions/60907323/accessing-class-property-as-decorator-argument
     def decorator(func):
+        @wraps(func)
         def cls_method(self, *args, **kwargs):
             f = func
             if self.regress_forces and not getattr(self, "direct_forces", 0):


### PR DESCRIPTION
This will allow us to get the inner function using the `model.forward.__wrapped__` attribute.

Use-case:
If we want to inspect the accepted parameters of the forward method of some model (that uses `conditional_grad`), we will not be able to cleanly do so (using the `inspect` module) as the forward method is wrapped using our function. With this PR, we can just use `inspect.signature(model.forward.__wrapped__)`.