### PR TITLE
PyG 2 Support Regression

### DIFF
--- a/ocpmodels/datasets/lmdb_dataset.py
+++ b/ocpmodels/datasets/lmdb_dataset.py
@@ -92,14 +92,11 @@ class LmdbDataset(Dataset):
                 .begin()
                 .get(f"{self._keys[db_idx][el_idx]}".encode("ascii"))
             )
-            data_object = pickle.loads(datapoint_pickled)
+            data_object = pyg2_data_transform(pickle.loads(datapoint_pickled))
             data_object.id = f"{db_idx}_{el_idx}"
         else:
             datapoint_pickled = self.env.begin().get(self._keys[idx])
-            data_object = pickle.loads(datapoint_pickled)
-
-        # make Data object compatible with PyG>=2.0
-        data_object = pyg2_data_transform(data_object)
+            data_object = pyg2_data_transform(pickle.loads(datapoint_pickled))
 
         if self.transform is not None:
             data_object = self.transform(data_object)

--- a/ocpmodels/datasets/lmdb_dataset.py
+++ b/ocpmodels/datasets/lmdb_dataset.py
@@ -98,11 +98,11 @@ class LmdbDataset(Dataset):
             datapoint_pickled = self.env.begin().get(self._keys[idx])
             data_object = pickle.loads(datapoint_pickled)
 
-        if self.transform is not None:
-            data_object = self.transform(data_object)
-
         # make Data object compatible with PyG>=2.0
         data_object = pyg2_data_transform(data_object)
+
+        if self.transform is not None:
+            data_object = self.transform(data_object)
 
         return data_object
 


### PR DESCRIPTION
The PyG-2 update transform is somewhat broken after #310. This update transform should run before any other code that accesses the PyG data objects (otherwise we will get an error). I've fixed that order in this PR.