### PR TITLE
bugfix for dict dataset definition

### DIFF
--- a/ocpmodels/trainers/energy_trainer.py
+++ b/ocpmodels/trainers/energy_trainer.py
@@ -285,9 +285,9 @@ class EnergyTrainer(BaseTrainer):
             torch.cuda.empty_cache()
 
         self.train_dataset.close_db()
-        if "val_dataset" in self.config:
+        if self.config.get("val_dataset", False):
             self.val_dataset.close_db()
-        if "test_dataset" in self.config:
+        if self.config.get("test_dataset", False):
             self.test_dataset.close_db()
 
     def _forward(self, batch_list):

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -404,9 +404,9 @@ class ForcesTrainer(BaseTrainer):
                 self.save(checkpoint_file="checkpoint.pt", training_state=True)
 
         self.train_dataset.close_db()
-        if "val_dataset" in self.config:
+        if self.config.get("val_dataset", False):
             self.val_dataset.close_db()
-        if "test_dataset" in self.config:
+        if self.config.get("test_dataset", False):
             self.test_dataset.close_db()
 
     def _forward(self, batch_list):


### PR DESCRIPTION
When defining datasets in the yaml configs via a dictionary format e.g.
```
dataset:
  train:
    src: data/s2ef/200k/train
    normalize_labels: False
  val:
    src: data/s2ef/all/val_id_30k
```

The current codebase registers all possible datasets in the config - https://github.com/Open-Catalyst-Project/ocp/blob/fe9998ecbe47e7984a5fa833fd9e4684e58b005b/ocpmodels/trainers/base_trainer.py#L162-L165 This results in the following error `AttributeError: 'ForcesTrainer' object has no attribute 'test_dataset'` once reaching these lines: https://github.com/Open-Catalyst-Project/ocp/blob/fe9998ecbe47e7984a5fa833fd9e4684e58b005b/ocpmodels/trainers/forces_trainer.py#L407-L410 since the condition is only examining if the key exists in `self.config` rather than checking if a valid entry exists.

This issue is avoided in the current configs that use a list definition for the datasets since they only get added to the configs if they exist - https://github.com/Open-Catalyst-Project/ocp/blob/fe9998ecbe47e7984a5fa833fd9e4684e58b005b/ocpmodels/trainers/base_trainer.py#L156-L161 Support for the dictionary is preferred since it allows one to easily modify paths from the command line.