### PR TITLE
gemnet scaling script fix

### DIFF
--- a/ocpmodels/models/gemnet/fit_scaling.py
+++ b/ocpmodels/models/gemnet/fit_scaling.py
@@ -82,7 +82,6 @@ if __name__ == "__main__":
         identifier=config["identifier"],
         run_dir=config.get("run_dir", "./"),
         is_debug=config.get("is_debug", False),
-        is_vis=config.get("is_vis", False),
         print_every=config.get("print_every", 10),
         seed=config.get("seed", 0),
         logger=config.get("logger", "tensorboard"),


### PR DESCRIPTION
An earlier PR removed `is_vis`, this script breaks otherwise. 