### PR TITLE
Removes extra context on GPU0 for distributed training

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
     - id: black
       language_version: python3.8
+      additional_dependencies: ['click==8.0.4']
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:

--- a/ocpmodels/common/distutils.py
+++ b/ocpmodels/common/distutils.py
@@ -50,6 +50,10 @@ def setup(config):
                 logging.info(
                     f"Init: {config['init_method']}, {config['world_size']}, {config['rank']}"
                 )
+
+                # ensures GPU0 does not have extra context/higher peak memory
+                torch.cuda.set_device(config["local_rank"])
+
                 dist.init_process_group(
                     backend=config["distributed_backend"],
                     init_method=config["init_method"],


### PR DESCRIPTION
This PR makes two changes:

1. Removes extra context on GPU0 during distributed training by setting the default device to local_rank  i.e. `torch.cuda.set_device(local_rank)`. My understanding is that certain operations like dataloading with memory pinning can create extra context on rank 0. I have seen two situations where this ends up being significant, one is training with apex optimizers (I am guessing this is model agnostic), the other is training NequIP. Below I have attached an example.
Without setting `torch.cuda.set_device(local_rank)`
![Screen Shot 2022-05-11 at 10 59 37 PM](https://user-images.githubusercontent.com/11530209/168003686-0ab6e7be-bdb1-45df-9e5d-5c938f78ddf8.png)
Setting `torch.cuda.set_device(local_rank)`
![Screen Shot 2022-05-11 at 10 58 58 PM](https://user-images.githubusercontent.com/11530209/168003888-93e8b729-96e9-4b05-9195-2c2369ef69d3.png)

2. Unrelated to the first change but we need to pin the version of click for black with pre-commit or update the rev https://github.com/psf/black/issues/2964#issuecomment-1080974737