### PR TITLE
Atomwise L2 loss

### DIFF
--- a/configs/is2re/example.yml
+++ b/configs/is2re/example.yml
@@ -1,0 +1,106 @@
+# Example config for training models for IS2RE.
+
+trainer: energy                                                                 # 'energy' or 'forces'
+
+task:
+  # The code currently only supports 'lmdb' for both IS2RE and S2EF.
+  #
+  # Can use 'single_point_lmdb' or 'trajectory_lmdb' for backward compatibility.
+  # 'single_point_lmdb' was for training IS2RE models, and 'trajectory_lmdb' for
+  # training S2EF models.
+  dataset: lmdb
+  # This is an optional parameter specifying the val metric to watch for
+  # improvement to decide when to save checkpoints.
+  # By default, this is:
+  #   'energy_force_within_threshold' for S2EF,
+  #   'energy_mae' for IS2RE,
+  #   'average_distance_within_threshold' for IS2RS.
+  primary_metric: energy_mae
+
+dataset:
+  train:
+    # Path to training set LMDB
+    src: data/is2re/all/train/data.lmdb
+    # If we want to normalize each target value, i.e. subtract the mean and
+    # divide by standard deviation, then those 'target_mean' and 'target_std'
+    # statistics need to be specified here for the train split.
+    normalize_labels: True                                                      # True or False
+    # These stats are for OC20 IS2RE.
+    target_mean: -1.525913953781128
+    target_std: 2.279365062713623
+  val:
+    # Path to val set LMDB
+    src: data/is2re/all/val_id/data.lmdb
+  test:
+    # Path to test set LMDB
+    src: data/is2re/all/test_id/data.lmdb
+
+logger: tensorboard                                                             # 'wandb' or 'tensorboard'
+
+model:
+  name: gemnet_t
+  # Model attributes go here, e.g. no. of layers, no. of hidden channels,
+  # embedding functions, cutoff radius, no. of neighbors, etc.
+  # This list of params will look different depending on the model.
+  #
+  # 'otf_graph' specifies whether graph edges should be computed on the fly
+  # or they already exist in the preprocessed LMDBs. If unsure, set it to True.
+  otf_graph: True                                                               # True or False
+  # All models in OCP can be used to predict just energies, or both energies and
+  # forces. For IS2RE, we don't need forces, so 'regress_forces' is False.
+  regress_forces: False                                                         # True or False
+
+optim:
+  # Batch size per GPU for training.
+  # Note that effective batch size will be 'batch_size' x no. of GPUs.
+  batch_size: 8
+  # Batch size per GPU for evaluation.
+  # Note that effective batch size will be 'eval_batch_size' x no. of GPUs.
+  eval_batch_size: 8
+  # No. of subprocesses to use for dataloading, pass as an arg to
+  # https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader.
+  num_workers: 2
+  # After how many updates to run evaluation on val during training.
+  # If unspecified, defaults to 1 epoch.
+  eval_every: 5000
+  # Loss function to use for energies. Defaults to 'mae'.
+  loss_energy: mae                                                              # 'mae' or 'mse'
+  # Optimizer to use from torch.optim.
+  # Default is https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html.
+  optimizer: AdamW
+  # Learning rate. Passed as an `lr` argument when initializing the optimizer.
+  lr_initial: 1.e-4
+  # Additional args needed to initialize the optimizer.
+  optimizer_params: {"amsgrad": True}
+  # Weight decay to use. Passed as an argument when initializing the optimizer.
+  weight_decay: 0
+  # Learning rate scheduler. Should work for any scheduler specified in
+  # in torch.optim.lr_scheduler: https://pytorch.org/docs/stable/optim.html
+  # as long as the relevant args are specified here.
+  #
+  # For example, for ReduceLROnPlateau, we specify `mode`, `factor`, `patience`.
+  # https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.ReduceLROnPlateau.html
+  #
+  # Note that if task.primary_metric specified earlier in the config is a metric
+  # where higher is better (e.g. 'energy_force_within_threshold' or
+  # 'average_distance_within_threshold'), `mode` should be 'max' since we'd want
+  # to step LR when the metric has stopped increasing. Vice versa for energy_mae
+  # or forces_mae or loss.
+  #
+  # If you don't want to use a scheduler, set it to 'Null' (yes type that out).
+  # This is for legacy reasons. If scheduler is unspecified, it defaults to
+  # 'LambdaLR': warming up the learning rate to 'lr_initial' and then stepping
+  # it at pre-defined set of steps. See the DimeNet++ config for how to do this.
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  patience: 3
+  # No. of epochs to train for.
+  max_epochs: 100
+  # Exponential moving average of parameters. 'ema_decay' is the decay factor.
+  ema_decay: 0.999
+  # Max norm of gradients for clipping. Uses torch.nn.utils.clip_grad_norm_.
+  clip_grad_norm: 10
+
+slurm:
+  constraint: "rtx_6000"

--- a/configs/s2ef/example.yml
+++ b/configs/s2ef/example.yml
@@ -1,0 +1,157 @@
+# Example config for training models for S2EF.
+
+trainer: forces                                                                 # 'energy' or 'forces'
+
+task:
+  # The code currently only supports 'lmdb' for both IS2RE and S2EF.
+  #
+  # Can use 'single_point_lmdb' or 'trajectory_lmdb' for backward compatibility.
+  # 'single_point_lmdb' was for training IS2RE models, and 'trajectory_lmdb' for
+  # training S2EF models.
+  dataset: lmdb
+  # This is an optional parameter specifying the val metric to watch for
+  # improvement to decide when to save checkpoints.
+  # By default, this is:
+  #   'energy_force_within_threshold' for S2EF,
+  #   'energy_mae' for IS2RE,
+  #   'average_distance_within_threshold' for IS2RS.
+  primary_metric: forces_mae
+  # OC20 systems had slab atoms fixed when running DFT calculations. Surface and
+  # adsorbate atoms were free to move. This info is available for each structure
+  # in the released LMDBs.
+  # These args specify whether to train/eval forces on only free atoms or all.
+  train_on_free_atoms: True                                                     # True or False
+  eval_on_free_atoms: True                                                      # True or False
+  # The following args in the 'task' tree are for running relaxations with an
+  # S2EF model during training (as additional validation) or testing.
+  # Totally optional if you're only looking to train an S2EF model.
+  #
+  # Whether to evaluate val relaxations when training S2EF models on the
+  # energy_mae and average_distance_within_threshold metrics.
+  eval_relaxations: False                                                       # True or False
+  # No. of batches to run relaxations on. Defaults to the full 'relax_dataset'.
+  num_relaxation_batches: 5
+  # Max no. of steps to run relaxations for.
+  relaxation_steps: 300
+  # Whether to save out the positions.
+  write_pos: True                                                               # True or False
+  # Path to initial structures to run relaxations on. Same as the IS2RE set.
+  relax_dataset:
+    src: data/is2re/all/test_id/data.lmdb
+  relax_opt:
+    name: lbfgs
+    maxstep: 0.04
+    memory: 50
+    damping: 1.0
+    alpha: 70.0
+    # Directory to save out trajectories (.traj files) in.
+    traj_dir: path/to/traj/directory
+
+dataset:
+  train:
+    # Directory containing training set LMDBs
+    src: data/s2ef/all/train/
+    # If we want to normalize each target value, i.e. subtract the mean and
+    # divide by standard deviation, then those 'target_mean' and 'target_std'
+    # statistics for energies and 'grad_target_mean' and 'grad_target_std'
+    # statistics for forces need to be specified here for the train split.
+    normalize_labels: True
+    # These stats are for OC20 S2EF.
+    target_mean: -0.7554450631141663
+    target_std: 2.887317180633545
+    grad_target_mean: 0.0
+    grad_target_std: 2.887317180633545
+  val:
+    # Directory containing val set LMDBs
+    src: data/s2ef/all/val_id/
+  test:
+    # Directory containing test set LMDBs
+    src: data/s2ef/all/test_id/
+
+logger: tensorboard                                                             # 'wandb' or 'tensorboard'
+
+model:
+  name: gemnet_t
+  # Model attributes go here, e.g. no. of layers, no. of hidden channels,
+  # embedding functions, cutoff radius, no. of neighbors, etc.
+  # This list of params will look different depending on the model.
+  #
+  # 'otf_graph' specifies whether graph edges should be computed on the fly
+  # or they already exist in the preprocessed LMDBs. If unsure, set it to True.
+  otf_graph: True                                                               # True or False
+  # All models in OCP can be used to predict just energies, or both energies and
+  # forces. For S2EF, we need both, so 'regress_forces' is True.
+  regress_forces: True                                                          # True or False
+  # Whether forces are predicted directly via an independent network (when set
+  # to True), or as negative gradients of energy wrt positions (when False)
+  direct_forces: True
+
+optim:
+  # Batch size per GPU for training.
+  # Note that effective batch size will be 'batch_size' x no. of GPUs.
+  batch_size: 8
+  # Batch size per GPU for evaluation.
+  # Note that effective batch size will be 'eval_batch_size' x no. of GPUs.
+  eval_batch_size: 8
+  # Whether to load balance across GPUs based on no. of 'atoms' or 'neighbors'.
+  load_balancing: atoms                                                         # 'atoms' or 'neighbors'
+  # No. of subprocesses to use for dataloading, pass as an arg to
+  # https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader.
+  num_workers: 2
+  # After how many updates to run evaluation on val during training.
+  # If unspecified, defaults to 1 epoch.
+  eval_every: 5000
+  # Loss function to use for energies. Defaults to 'mae'.
+  loss_energy: mae                                                              # 'mae' or 'mse'
+  # Loss function to use for forces. Defaults to 'mae'.
+  #
+  # 'l2mae' has been working well for us with a force to energy coefficient
+  # ratio of 100:1.
+  #
+  # When training on raw DFT energies, 'atomwisel2' might be a better default
+  # with a force to energy coefficient ratio of 1:1. 'atomwisel2' scales L2 loss
+  # for forces by the no. of atoms in the structure.
+  loss_force: l2mae                                                             # 'mae' or 'mse' or 'l2mae' or 'atomwisel2'
+  # Coefficient to use for the energy loss.
+  energy_coefficient: 1
+  # Coefficient to use for the force loss.
+  force_coefficient: 100
+  # Optimizer to use from torch.optim.
+  # Default is https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html.
+  optimizer: AdamW
+  # Learning rate. Passed as an `lr` argument when initializing the optimizer.
+  lr_initial: 1.e-4
+  # Additional args needed to initialize the optimizer.
+  optimizer_params: {"amsgrad": True}
+  # Weight decay to use. Passed as an argument when initializing the optimizer.
+  weight_decay: 0
+  # Learning rate scheduler. Should work for any scheduler specified in
+  # in torch.optim.lr_scheduler: https://pytorch.org/docs/stable/optim.html
+  # as long as the relevant args are specified here.
+  #
+  # For example, for ReduceLROnPlateau, we specify `mode`, `factor`, `patience`.
+  # https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.ReduceLROnPlateau.html
+  #
+  # Note that if task.primary_metric specified earlier in the config is a metric
+  # where higher is better (e.g. 'energy_force_within_threshold' or
+  # 'average_distance_within_threshold'), `mode` should be 'max' since we'd want
+  # to step LR when the metric has stopped increasing. Vice versa for energy_mae
+  # or forces_mae or loss.
+  #
+  # If you don't want to use a scheduler, set it to 'Null' (yes type that out).
+  # This is for legacy reasons. If scheduler is unspecified, it defaults to
+  # 'LambdaLR': warming up the learning rate to 'lr_initial' and then stepping
+  # it at pre-defined set of steps. See the DimeNet++ config for how to do this.
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  patience: 3
+  # No. of epochs to train for.
+  max_epochs: 100
+  # Exponential moving average of parameters. 'ema_decay' is the decay factor.
+  ema_decay: 0.999
+  # Max norm of gradients for clipping. Uses torch.nn.utils.clip_grad_norm_.
+  clip_grad_norm: 10
+
+slurm:
+  constraint: "rtx_6000"

--- a/ocpmodels/modules/loss.py
+++ b/ocpmodels/modules/loss.py
@@ -36,6 +36,27 @@ class AtomwiseMSELoss(nn.Module):
             return loss.sum()
 
 
+class AtomwiseL2MAELoss(nn.Module):
+    def __init__(self, reduction="mean"):
+        super().__init__()
+        self.reduction = reduction
+        assert reduction in ["mean", "sum"]
+
+    def forward(
+        self, input: torch.Tensor, target: torch.Tensor, natoms: torch.Tensor
+    ):
+        assert natoms.shape[0] == input.shape[0] == target.shape[0]
+        assert len(natoms.shape) == 1  # (nAtoms, )
+
+        dists = torch.norm(input - target, p=2, dim=-1)
+        loss = natoms * dists
+
+        if self.reduction == "mean":
+            return torch.mean(loss)
+        elif self.reduction == "sum":
+            return torch.sum(loss)
+
+
 class DDPLoss(nn.Module):
     def __init__(self, loss_fn, reduction="mean"):
         super().__init__()

--- a/ocpmodels/modules/loss.py
+++ b/ocpmodels/modules/loss.py
@@ -18,25 +18,7 @@ class L2MAELoss(nn.Module):
             return torch.sum(dists)
 
 
-class AtomwiseMSELoss(nn.Module):
-    def __init__(self, reduction="mean"):
-        super().__init__()
-        self.reduction = reduction
-        assert reduction in ["mean", "sum"]
-
-    def forward(
-        self, input: torch.Tensor, target: torch.Tensor, natoms: torch.Tensor
-    ):
-        assert natoms.shape[0] == input.shape[0] == target.shape[0]
-        assert len(natoms.shape) == 1  # (nAtoms, )
-        loss = natoms * ((input - target) ** 2).mean(-1)  # Avg across x,y,z
-        if self.reduction == "mean":
-            return loss.mean()
-        elif self.reduction == "sum":
-            return loss.sum()
-
-
-class AtomwiseL2MAELoss(nn.Module):
+class AtomwiseL2Loss(nn.Module):
     def __init__(self, reduction="mean"):
         super().__init__()
         self.reduction = reduction

--- a/ocpmodels/modules/loss.py
+++ b/ocpmodels/modules/loss.py
@@ -18,6 +18,24 @@ class L2MAELoss(nn.Module):
             return torch.sum(dists)
 
 
+class AtomwiseMSELoss(nn.Module):
+    def __init__(self, reduction="mean"):
+        super().__init__()
+        self.reduction = reduction
+        assert reduction in ["mean", "sum"]
+
+    def forward(
+        self, input: torch.Tensor, target: torch.Tensor, natoms: torch.Tensor
+    ):
+        assert natoms.shape[0] == input.shape[0] == target.shape[0]
+        assert len(natoms.shape) == 1  # (nAtoms, )
+        loss = natoms * ((input - target) ** 2).mean(-1)  # Avg across x,y,z
+        if self.reduction == "mean":
+            return loss.mean()
+        elif self.reduction == "sum":
+            return loss.sum()
+
+
 class DDPLoss(nn.Module):
     def __init__(self, loss_fn, reduction="mean"):
         super().__init__()
@@ -26,10 +44,21 @@ class DDPLoss(nn.Module):
         self.reduction = reduction
         assert reduction in ["mean", "sum"]
 
-    def forward(self, input: torch.Tensor, target: torch.Tensor):
-        loss = self.loss_fn(input, target)
+    def forward(
+        self,
+        input: torch.Tensor,
+        target: torch.Tensor,
+        natoms: torch.Tensor = None,
+        batch_size: int = None,
+    ):
+        if natoms is None:
+            loss = self.loss_fn(input, target)
+        else:  # atom-wise loss
+            loss = self.loss_fn(input, target, natoms)
         if self.reduction == "mean":
-            num_samples = input.shape[0]
+            num_samples = (
+                batch_size if batch_size is not None else input.shape[0]
+            )
             num_samples = distutils.all_reduce(
                 num_samples, device=input.device
             )

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -41,7 +41,7 @@ from ocpmodels.modules.evaluator import Evaluator
 from ocpmodels.modules.exponential_moving_average import (
     ExponentialMovingAverage,
 )
-from ocpmodels.modules.loss import DDPLoss, L2MAELoss
+from ocpmodels.modules.loss import AtomwiseMSELoss, DDPLoss, L2MAELoss
 from ocpmodels.modules.normalizer import Normalizer
 from ocpmodels.modules.scheduler import LRScheduler
 
@@ -442,6 +442,8 @@ class BaseTrainer(ABC):
                 self.loss_fn[loss] = nn.MSELoss()
             elif loss_name == "l2mae":
                 self.loss_fn[loss] = L2MAELoss()
+            elif loss_name == "atomwisemse":
+                self.loss_fn[loss] = AtomwiseMSELoss()
             else:
                 raise NotImplementedError(
                     f"Unknown loss function name: {loss_name}"

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -41,7 +41,12 @@ from ocpmodels.modules.evaluator import Evaluator
 from ocpmodels.modules.exponential_moving_average import (
     ExponentialMovingAverage,
 )
-from ocpmodels.modules.loss import AtomwiseMSELoss, DDPLoss, L2MAELoss
+from ocpmodels.modules.loss import (
+    AtomwiseL2MAELoss,
+    AtomwiseMSELoss,
+    DDPLoss,
+    L2MAELoss,
+)
 from ocpmodels.modules.normalizer import Normalizer
 from ocpmodels.modules.scheduler import LRScheduler
 
@@ -444,6 +449,8 @@ class BaseTrainer(ABC):
                 self.loss_fn[loss] = L2MAELoss()
             elif loss_name == "atomwisemse":
                 self.loss_fn[loss] = AtomwiseMSELoss()
+            elif loss_name == "atomwisel2mae":
+                self.loss_fn[loss] = AtomwiseL2MAELoss()
             else:
                 raise NotImplementedError(
                     f"Unknown loss function name: {loss_name}"

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -41,12 +41,7 @@ from ocpmodels.modules.evaluator import Evaluator
 from ocpmodels.modules.exponential_moving_average import (
     ExponentialMovingAverage,
 )
-from ocpmodels.modules.loss import (
-    AtomwiseL2MAELoss,
-    AtomwiseMSELoss,
-    DDPLoss,
-    L2MAELoss,
-)
+from ocpmodels.modules.loss import AtomwiseL2Loss, DDPLoss, L2MAELoss
 from ocpmodels.modules.normalizer import Normalizer
 from ocpmodels.modules.scheduler import LRScheduler
 
@@ -447,10 +442,8 @@ class BaseTrainer(ABC):
                 self.loss_fn[loss] = nn.MSELoss()
             elif loss_name == "l2mae":
                 self.loss_fn[loss] = L2MAELoss()
-            elif loss_name == "atomwisemse":
-                self.loss_fn[loss] = AtomwiseMSELoss()
-            elif loss_name == "atomwisel2mae":
-                self.loss_fn[loss] = AtomwiseL2MAELoss()
+            elif loss_name == "atomwisel2":
+                self.loss_fn[loss] = AtomwiseL2Loss()
             else:
                 raise NotImplementedError(
                     f"Unknown loss function name: {loss_name}"

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -489,15 +489,17 @@ class ForcesTrainer(BaseTrainer):
                 loss.append(train_loss_force_normalized)
 
             else:
+                # Force coefficient = 30 has been working well for us.
+                force_mult = self.config["optim"].get("force_coefficient", 30)
                 if self.config["task"].get("train_on_free_atoms", False):
-                    force_mult = self.config["optim"].get(
-                        "force_coefficient", 1
-                    )
                     fixed = torch.cat(
                         [batch.fixed.to(self.device) for batch in batch_list]
                     )
                     mask = fixed == 0
                     if self.config["optim"]["loss_force"] == "atomwisemse":
+                        force_mult = self.config["optim"].get(
+                            "force_coefficient", 1
+                        )
                         natoms = torch.cat(
                             [
                                 batch.natoms.to(self.device)
@@ -520,10 +522,6 @@ class ForcesTrainer(BaseTrainer):
                             )
                         )
                 else:
-                    # Force coefficient = 30 has been working well for us.
-                    force_mult = self.config["optim"].get(
-                        "force_coefficient", 30
-                    )
                     loss.append(
                         force_mult
                         * self.loss_fn["force"](out["forces"], force_target)

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -509,7 +509,7 @@ class ForcesTrainer(BaseTrainer):
                             out["forces"][mask],
                             force_target[mask],
                             natoms=natoms[mask],
-                            batch_size=self.config["optim"]["batch_size"],
+                            batch_size=batch_list[0].natoms.shape[0],
                         )
                         loss.append(force_loss)
                     else:

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -496,7 +496,9 @@ class ForcesTrainer(BaseTrainer):
                         [batch.fixed.to(self.device) for batch in batch_list]
                     )
                     mask = fixed == 0
-                    if self.config["optim"]["loss_force"] == "atomwisemse":
+                    if self.config["optim"]["loss_force"].startswith(
+                        "atomwise"
+                    ):
                         force_mult = self.config["optim"].get(
                             "force_coefficient", 1
                         )


### PR DESCRIPTION
Scales L2 loss for forces by the no. of atoms in the structure.

Better default than picking an arbitrary constant force coefficient across structures of different sizes, and should allow for a 1:1 relative weighting of energy to force loss to work reasonably well.

Can be used by setting `loss_force: atomwisel2` in the config (make sure to set `force_coefficient: 1`).