### PR TITLE
Bugfix in best val metric check for checkpointing

### DIFF
--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -264,7 +264,10 @@ class ForcesTrainer(BaseTrainer):
         if (
             "mae" in primary_metric
             and val_metrics[primary_metric]["metric"] < self.best_val_metric
-        ) or (val_metrics[primary_metric]["metric"] > self.best_val_metric):
+        ) or (
+            "mae" not in primary_metric
+            and val_metrics[primary_metric]["metric"] > self.best_val_metric
+        ):
             self.best_val_metric = val_metrics[primary_metric]["metric"]
             self.save(
                 metrics=val_metrics,


### PR DESCRIPTION
There was a bug in the logic for deciding whether to checkpoint based on val error metrics, causing it to always save the most recent weights. This PR fixes that.