### PR TITLE
atomwise l2 bugfix for non-ddp 

### DIFF
--- a/ocpmodels/modules/loss.py
+++ b/ocpmodels/modules/loss.py
@@ -29,7 +29,6 @@ class AtomwiseL2Loss(nn.Module):
         input: torch.Tensor,
         target: torch.Tensor,
         natoms: torch.Tensor,
-        batch_size: torch.Tensor = None,  # not used
     ):
         assert natoms.shape[0] == input.shape[0] == target.shape[0]
         assert len(natoms.shape) == 1  # (nAtoms, )

--- a/ocpmodels/modules/loss.py
+++ b/ocpmodels/modules/loss.py
@@ -25,7 +25,11 @@ class AtomwiseL2Loss(nn.Module):
         assert reduction in ["mean", "sum"]
 
     def forward(
-        self, input: torch.Tensor, target: torch.Tensor, natoms: torch.Tensor
+        self,
+        input: torch.Tensor,
+        target: torch.Tensor,
+        natoms: torch.Tensor,
+        batch_size: torch.Tensor = None,  # not used
     ):
         assert natoms.shape[0] == input.shape[0] == target.shape[0]
         assert len(natoms.shape) == 1  # (nAtoms, )

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -448,8 +448,7 @@ class BaseTrainer(ABC):
                 raise NotImplementedError(
                     f"Unknown loss function name: {loss_name}"
                 )
-            if distutils.initialized():
-                self.loss_fn[loss] = DDPLoss(self.loss_fn[loss])
+            self.loss_fn[loss] = DDPLoss(self.loss_fn[loss])
 
     def load_optimizer(self):
         optimizer = self.config["optim"].get("optimizer", "AdamW")


### PR DESCRIPTION
https://github.com/Open-Catalyst-Project/ocp/blob/d3fc9d08173c968c92bae330a8d4b850822c2d24/ocpmodels/trainers/forces_trainer.py#L519 `batch_size` is only a valid argument when using `DDPLoss`. This PR resolves that for instances with only 1 GPU. Alternatively, we can remove this condition https://github.com/Open-Catalyst-Project/ocp/blob/d3fc9d08173c968c92bae330a8d4b850822c2d24/ocpmodels/trainers/base_trainer.py#L451 and have all losses go through `DDPLoss` regardless of GPUs since `all_reduce` is still a valid call under 1 GPU. I've tested both approaches and they work fine. Any preference?