### PR TITLE
Make sure best val metric is loaded when restoring checkpoint

### DIFF
--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -394,6 +394,8 @@ class BaseTrainer(ABC):
         checkpoint = torch.load(checkpoint_path, map_location=map_location)
         self.epoch = checkpoint.get("epoch", 0)
         self.step = checkpoint.get("step", 0)
+        self.best_val_metric = checkpoint.get("best_val_metric", None)
+        self.primary_metric = checkpoint.get("primary_metric", None)
 
         # Load model, optimizer, normalizer state dict.
         # if trained with ddp and want to load in non-ddp, modify keys from
@@ -527,6 +529,11 @@ class BaseTrainer(ABC):
                         "amp": self.scaler.state_dict()
                         if self.scaler
                         else None,
+                        "best_val_metric": self.best_val_metric,
+                        "primary_metric": self.config["task"].get(
+                            "primary_metric",
+                            self.evaluator.task_primary_metric[self.name],
+                        ),
                     },
                     checkpoint_dir=self.config["cmd"]["checkpoint_dir"],
                     checkpoint_file=checkpoint_file,

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -291,7 +291,13 @@ class ForcesTrainer(BaseTrainer):
         primary_metric = self.config["task"].get(
             "primary_metric", self.evaluator.task_primary_metric[self.name]
         )
-        self.best_val_metric = 1e9 if "mae" in primary_metric else -1.0
+        if (
+            self.primary_metric is None
+            or self.primary_metric != primary_metric
+        ):
+            self.best_val_metric = 1e9 if "mae" in primary_metric else -1.0
+        else:
+            primary_metric = self.primary_metric
         self.metrics = {}
 
         # Calculate start_epoch from step instead of loading the epoch number


### PR DESCRIPTION
In cases where the training job gets relaunched after val metrics have started deteriorating, the `best_val_metric` variable getting reset meant that the wrong model weights are saved in `best_checkpoint.pt`. This PR fixes that.