### PR TITLE
bugfix PR#343

### DIFF
--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -499,8 +499,10 @@ class ForcesTrainer(BaseTrainer):
                         [batch.fixed.to(self.device) for batch in batch_list]
                     )
                     mask = fixed == 0
-                    if self.config["optim"]["loss_force"].startswith(
-                        "atomwise"
+                    if (
+                        self.config["optim"]
+                        .get("loss_force", "mae")
+                        .startswith("atomwise")
                     ):
                         force_mult = self.config["optim"].get(
                             "force_coefficient", 1


### PR DESCRIPTION
Small fix to PR #343 - it assumes all configs have `loss_force` in their configs. Defaults `loss_force` to what we define [here](https://github.com/Open-Catalyst-Project/ocp/blob/922ec72e1e20637fb5b537f304d797779bd46a4d/ocpmodels/trainers/base_trainer.py#L439)