### PR TITLE
Update environment installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,15 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/python:3.8
-    resource_class: medium+
+      - image: cimg/python:3.8
+    resource_class: large
 
     steps:
       - checkout
 
       - restore_cache:
           keys:
-          - v0.3-dependencies-{{ checksum "env.common.yml" }}-{{ checksum "env.cpu.yml" }}-{{ checksum "env.gpu.yml" }}
+          - v0.4-dependencies-{{ checksum "env.common.yml" }}-{{ checksum "env.cpu.yml" }}-{{ checksum "env.gpu.yml" }}
 
       - run:
           name: Install conda
@@ -39,7 +39,7 @@ jobs:
       - save_cache:
           paths:
             - /home/circleci/miniconda
-          key: v0.3-dependencies-{{ checksum "env.common.yml" }}-{{ checksum "env.cpu.yml" }}-{{ checksum "env.gpu.yml" }}
+          key: v0.4-dependencies-{{ checksum "env.common.yml" }}-{{ checksum "env.cpu.yml" }}-{{ checksum "env.gpu.yml" }}
 
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,5 +55,5 @@ jobs:
           command: |
             source /home/circleci/miniconda/etc/profile.d/conda.sh
             conda activate ocp-models
-            pip install black==20.8b1
+            pip install black==22.3.0
             black . --check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     docker:
       - image: cimg/python:3.8
-    resource_class: large
+    resource_class: medium+
 
     steps:
       - checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3.8

--- a/env.common.yml
+++ b/env.common.yml
@@ -21,7 +21,7 @@ dependencies:
   - numba
   - pip:
     - Pillow
-    - torch-geometric==1.7.2
+    - git+https://github.com/pyg-team/pytorch_geometric.git@9a8ae98
     - wandb
     - lmdb==1.1.1
     - pytest==6.2.2

--- a/env.common.yml
+++ b/env.common.yml
@@ -21,7 +21,7 @@ dependencies:
   - numba
   - pip:
     - Pillow
-    - torch-geometric==2.0.3
+    - git+https://github.com/pyg-team/pytorch_geometric.git@a7e6be4
     - wandb
     - lmdb==1.1.1
     - pytest==6.2.2

--- a/env.common.yml
+++ b/env.common.yml
@@ -21,7 +21,7 @@ dependencies:
   - numba
   - pip:
     - Pillow
-    - git+https://github.com/pyg-team/pytorch_geometric.git@9a8ae98
+    - git+https://github.com/pyg-team/pytorch_geometric.git@a7e6be4
     - wandb
     - lmdb==1.1.1
     - pytest==6.2.2

--- a/env.common.yml
+++ b/env.common.yml
@@ -9,8 +9,8 @@ dependencies:
   - pip
   - pre-commit=2.10.*
   - pymatgen=2020.12.31
-  - python=3.9.*
-  - pytorch=1.10.1
+  - python=3.8.*
+  - pytorch=1.9.0
   - pyyaml=5.4.*
   - tensorboard=2.5.*
   - tqdm=4.58.*
@@ -21,7 +21,7 @@ dependencies:
   - numba
   - pip:
     - Pillow
-    - git+https://github.com/pyg-team/pytorch_geometric.git@a7e6be4
+    - torch-geometric==2.0.3
     - wandb
     - lmdb==1.1.1
     - pytest==6.2.2

--- a/env.common.yml
+++ b/env.common.yml
@@ -9,8 +9,8 @@ dependencies:
   - pip
   - pre-commit=2.10.*
   - pymatgen=2020.12.31
-  - python=3.8.*
-  - pytorch=1.9.0
+  - python=3.9.*
+  - pytorch=1.10.1
   - pyyaml=5.4.*
   - tensorboard=2.5.*
   - tqdm=4.58.*

--- a/env.common.yml
+++ b/env.common.yml
@@ -17,7 +17,7 @@ dependencies:
   - sphinx
   - nbsphinx
   - pandoc
-  - black
+  - black==22.3.0
   - numba
   - pip:
     - Pillow

--- a/env.cpu.yml
+++ b/env.cpu.yml
@@ -1,7 +1,7 @@
 dependencies:
   - cpuonly
   - pip:
-    - -f https://pytorch-geometric.com/whl/torch-1.9.0+cpu.html
+    - -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
     - torch-cluster
     - torch-scatter
     - torch-sparse

--- a/env.cpu.yml
+++ b/env.cpu.yml
@@ -1,7 +1,7 @@
 dependencies:
   - cpuonly
   - pip:
-    - -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
+    - -f https://data.pyg.org/whl/torch-1.9.0+cpu.html
     - torch-cluster
     - torch-scatter
     - torch-sparse

--- a/env.cpu.yml
+++ b/env.cpu.yml
@@ -1,7 +1,7 @@
 dependencies:
   - cpuonly
   - pip:
-    - -f https://data.pyg.org/whl/torch-1.9.0+cpu.html
+    - -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
     - torch-cluster
     - torch-scatter
     - torch-sparse

--- a/env.gpu.yml
+++ b/env.gpu.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - cudatoolkit=11.1
   - pip:
-    - -f https://data.pyg.org/whl/torch-1.9.0+cu111.html
+    - -f https://data.pyg.org/whl/torch-1.10.0+cu111.html
     - torch-cluster
     - torch-scatter
     - torch-sparse

--- a/env.gpu.yml
+++ b/env.gpu.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - cudatoolkit=10.2
   - pip:
-    - -f https://pytorch-geometric.com/whl/torch-1.9.0+cu102.html
+    - -f https://data.pyg.org/whl/torch-1.10.0+cu102.html
     - torch-cluster
     - torch-scatter
     - torch-sparse

--- a/env.gpu.yml
+++ b/env.gpu.yml
@@ -3,9 +3,9 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - cudatoolkit=10.2
+  - cudatoolkit=11.1
   - pip:
-    - -f https://data.pyg.org/whl/torch-1.10.0+cu102.html
+    - -f https://data.pyg.org/whl/torch-1.9.0+cu111.html
     - torch-cluster
     - torch-scatter
     - torch-sparse

--- a/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
+++ b/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
@@ -71,7 +71,7 @@ class LBFGS:
         if forces is None:
             return False
         max_forces_ = scatter(
-            (forces ** 2).sum(axis=1).sqrt(), self.atoms.batch, reduce="max"
+            (forces**2).sum(axis=1).sqrt(), self.atoms.batch, reduce="max"
         )
         max_forces = max_forces_[self.atoms.batch]
         update_mask = torch.logical_and(

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -214,7 +214,7 @@ def add_edge_distance_to_graph(
     var = gdf_filter[1] - gdf_filter[0]
     gdf_filter, var = gdf_filter.to(device), var.to(device)
     gdf_distances = torch.exp(
-        -((distances.view(-1, 1) - gdf_filter) ** 2) / var ** 2
+        -((distances.view(-1, 1) - gdf_filter) ** 2) / var**2
     )
     # Reassign edge attributes.
     batch.edge_weight = distances
@@ -514,7 +514,7 @@ def radius_graph_pbc(data, radius, max_num_neighbors_threshold):
 
     # Before computing the pairwise distances between atoms, first create a list of atom indices to compare for the entire batch
     num_atoms_per_image = data.natoms
-    num_atoms_per_image_sqr = (num_atoms_per_image ** 2).long()
+    num_atoms_per_image_sqr = (num_atoms_per_image**2).long()
 
     # index offset between images
     index_offset = (

--- a/ocpmodels/models/gemnet/layers/basis_utils.py
+++ b/ocpmodels/models/gemnet/layers/basis_utils.py
@@ -156,7 +156,7 @@ def associated_legendre_polynomials(
             for l_degree in range(1, L_maxdegree):
                 P_l_m[l_degree][l_degree] = sym.simplify(
                     (1 - 2 * l_degree)
-                    * (1 - z ** 2) ** 0.5
+                    * (1 - z**2) ** 0.5
                     * P_l_m[l_degree - 1][l_degree - 1]
                 )  # P_00, P_11, P_22, P_33
 
@@ -259,7 +259,7 @@ def real_sph_harm(L_maxdegree, use_theta, use_phi=True, zero_m_only=True):
             # m > 0
             for m_order in range(1, l_degree + 1):
                 Y_l_m[l_degree][m_order] = sym.simplify(
-                    2 ** 0.5
+                    2**0.5
                     * (-1) ** m_order
                     * sph_harm_prefactor(l_degree, m_order)
                     * P_l_m[l_degree][m_order]
@@ -268,7 +268,7 @@ def real_sph_harm(L_maxdegree, use_theta, use_phi=True, zero_m_only=True):
             # m < 0
             for m_order in range(1, l_degree + 1):
                 Y_l_m[l_degree][-m_order] = sym.simplify(
-                    2 ** 0.5
+                    2**0.5
                     * (-1) ** m_order
                     * sph_harm_prefactor(l_degree, -m_order)
                     * P_l_m[l_degree][m_order]

--- a/ocpmodels/models/gemnet/layers/radial_basis.py
+++ b/ocpmodels/models/gemnet/layers/radial_basis.py
@@ -34,7 +34,7 @@ class PolynomialEnvelope(torch.nn.Module):
     def forward(self, d_scaled):
         env_val = (
             1
-            + self.a * d_scaled ** self.p
+            + self.a * d_scaled**self.p
             + self.b * d_scaled ** (self.p + 1)
             + self.c * d_scaled ** (self.p + 2)
         )
@@ -54,7 +54,7 @@ class ExponentialEnvelope(torch.nn.Module):
 
     def forward(self, d_scaled):
         env_val = torch.exp(
-            -(d_scaled ** 2) / ((1 - d_scaled) * (1 + d_scaled))
+            -(d_scaled**2) / ((1 - d_scaled) * (1 + d_scaled))
         )
         return torch.where(d_scaled < 1, env_val, torch.zeros_like(d_scaled))
 
@@ -77,7 +77,7 @@ class SphericalBesselBasis(torch.nn.Module):
         cutoff: float,
     ):
         super().__init__()
-        self.norm_const = math.sqrt(2 / (cutoff ** 3))
+        self.norm_const = math.sqrt(2 / (cutoff**3))
         # cutoff ** 3 to counteract dividing by d_scaled = d / cutoff
 
         # Initialize frequencies at canonical positions
@@ -141,7 +141,7 @@ class BernsteinBasis(torch.nn.Module):
         gamma = self.softplus(self.pregamma)  # constrain to positive
         exp_d = torch.exp(-gamma * d_scaled)[:, None]
         return (
-            self.prefactor * (exp_d ** self.exp1) * ((1 - exp_d) ** self.exp2)
+            self.prefactor * (exp_d**self.exp1) * ((1 - exp_d) ** self.exp2)
         )
 
 

--- a/ocpmodels/models/gemnet/utils.py
+++ b/ocpmodels/models/gemnet/utils.py
@@ -259,7 +259,7 @@ def calculate_interatomic_vectors(R, id_s, id_t, offsets_st):
         V_st = Rt - Rs  # s -> t
     else:
         V_st = Rt - Rs + offsets_st  # s -> t
-    D_st = torch.sqrt(torch.sum(V_st ** 2, dim=1))
+    D_st = torch.sqrt(torch.sum(V_st**2, dim=1))
     V_st = V_st / D_st[..., None]
     return D_st, V_st
 

--- a/ocpmodels/models/painn/painn.py
+++ b/ocpmodels/models/painn/painn.py
@@ -439,12 +439,15 @@ class PaiNN(ScaledModule):
                 forces = self.out_forces(x, vec)
                 return energy, forces
             else:
-                forces = -1 * torch.autograd.grad(
-                    x,
-                    pos,
-                    grad_outputs=torch.ones_like(x),
-                    create_graph=True,
-                )[0]
+                forces = (
+                    -1
+                    * torch.autograd.grad(
+                        x,
+                        pos,
+                        grad_outputs=torch.ones_like(x),
+                        create_graph=True,
+                    )[0]
+                )
                 return energy, forces
         else:
             return energy
@@ -577,7 +580,7 @@ class PaiNNUpdate(ScaledModule):
         # Add an epsilon offset to make sure sqrt is always positive.
         x_vec_h = self.xvec_proj(
             torch.cat(
-                [x, torch.sqrt(torch.sum(vec2 ** 2, dim=-2) + 1e-8)], dim=-1
+                [x, torch.sqrt(torch.sum(vec2**2, dim=-2) + 1e-8)], dim=-1
             )
         )
         xvec1, xvec2, xvec3 = torch.split(

--- a/ocpmodels/models/painn/utils.py
+++ b/ocpmodels/models/painn/utils.py
@@ -159,10 +159,10 @@ def get_edge_id(edge_idx, cell_offsets, num_atoms):
     cell_id = (
         (
             cell_offsets
-            * cell_offsets.new_tensor([[1, cell_basis, cell_basis ** 2]])
+            * cell_offsets.new_tensor([[1, cell_basis, cell_basis**2]])
         )
         .sum(-1)
         .long()
     )
-    edge_id = edge_idx[0] + edge_idx[1] * num_atoms + cell_id * num_atoms ** 2
+    edge_id = edge_idx[0] + edge_idx[1] * num_atoms + cell_id * num_atoms**2
     return edge_id

--- a/ocpmodels/models/spinconv.py
+++ b/ocpmodels/models/spinconv.py
@@ -615,7 +615,7 @@ class spinconv(BaseModel):
         num_atoms = len(data.batch)
 
         edge_vec_0 = edge_distance_vec
-        edge_vec_0_distance = torch.sqrt(torch.sum(edge_vec_0 ** 2, dim=1))
+        edge_vec_0_distance = torch.sqrt(torch.sum(edge_vec_0**2, dim=1))
 
         if torch.min(edge_vec_0_distance) < 0.0001:
             print(
@@ -643,7 +643,7 @@ class spinconv(BaseModel):
         )
 
         edge_vec_2 = avg_vector[edge_index[1, :]] + 0.0001
-        edge_vec_2_distance = torch.sqrt(torch.sum(edge_vec_2 ** 2, dim=1))
+        edge_vec_2_distance = torch.sqrt(torch.sum(edge_vec_2**2, dim=1))
 
         if torch.min(edge_vec_2_distance) < 0.000001:
             print(
@@ -656,11 +656,11 @@ class spinconv(BaseModel):
         norm_0_2 = edge_vec_2 / (edge_vec_2_distance.view(-1, 1))
         norm_z = torch.cross(norm_x, norm_0_2, dim=1)
         norm_z = norm_z / (
-            torch.sqrt(torch.sum(norm_z ** 2, dim=1, keepdim=True)) + 0.0000001
+            torch.sqrt(torch.sum(norm_z**2, dim=1, keepdim=True)) + 0.0000001
         )
         norm_y = torch.cross(norm_x, norm_z, dim=1)
         norm_y = norm_y / (
-            torch.sqrt(torch.sum(norm_y ** 2, dim=1, keepdim=True)) + 0.0000001
+            torch.sqrt(torch.sum(norm_y**2, dim=1, keepdim=True)) + 0.0000001
         )
 
         norm_x = norm_x.view(-1, 3, 1)


### PR DESCRIPTION
Current installation instructions are outdated and cause issues (see CI builds and #348). This updates wheels. Note #336 will replace this as a conda-only installation is a lot cleaner, but we'll need to wait until PyG 2.0.5 hits conda as it currently has a bug with DimeNet++.