### PR TITLE
OC20 Bader charge data release

### DIFF
--- a/DATASET.md
+++ b/DATASET.md
@@ -5,6 +5,7 @@
     * [Structure to Energy and Forces (S2EF)](#structure-to-energy-and-forces-s2ef-task)
     * [Initial Structure to Relaxed Structure (IS2RS) / Relaxed Energy (IS2RE)](#initial-structure-to-relaxed-structure-is2rs-and-initial-structure-to-relaxed-energy-is2re-tasks)
     * [Relaxation Trajectories](#relaxation-trajectories)
+    * [Bader charge data](#bader-charge-data)
     * [OC20 metadata](#oc20-mappings)
     * [Changelog](#dataset-changelog)
     * [License and bibtex](#citing-oc20)
@@ -163,6 +164,10 @@ Adsorbate+catalyst trajectories on a per adsorbate basis are provided [here](./D
 |294k systems    |20G    |151G    | [347f4183465810e9b384e7a033baefc7](https://dl.fbaipublicfiles.com/opencatalystproject/data/slab_trajectories.tar)    |
 
 
+### Bader charge data
+We provide Bader charge data for all final frames of our train + validation systems in OC20 (for both S2EF and IS2RE/RS tasks). A `.tar.gz` file, when downloaded and uncompressed will contain several directories with unique system-ids (of the format `random<XYZ>` where `XYZ` is an integer). Each directory will contain raw Bader charge analysis outputs. For more details on the Bader charge analysis, see https://theory.cm.utexas.edu/henkelman/research/bader/. 
+
+Downloadable link: https://dl.fbaipublicfiles.com/opencatalystproject/data/oc20_bader_data.tar (MD5 checksum: `aecc5e23542de49beceb4b7e44c153b9`)
 
 ### OC20 mappings
 


### PR DESCRIPTION
Includes a download to OC20 Bader charge data analysis ran as part of the original paper release. Bader charge analysis is provided for all final frames of our train+validation systems (for both S2EF + IS2RE/RS).

For more details on the analysis - visit https://theory.cm.utexas.edu/henkelman/research/bader/