### PR TITLE
Bugfix: Data created with PyG>2.0

### DIFF
--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -33,10 +33,10 @@ from torch_scatter import segment_coo, segment_csr
 
 
 def pyg2_data_transform(data: Data):
-    '''
-    if we're on the new pyg (2.0 or later) and if the Data stored is in older format  
+    """
+    if we're on the new pyg (2.0 or later) and if the Data stored is in older format
     we need to convert the data to the new format
-    '''
+    """
     if torch_geometric.__version__ >= "2.0" and "_store" not in data.__dict__:
         return Data(
             **{k: v for k, v in data.__dict__.items() if v is not None}

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -1,5 +1,6 @@
 """
 Copyright (c) Facebook, Inc. and its affiliates.
+
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
@@ -19,7 +20,6 @@ from bisect import bisect
 from functools import wraps
 from itertools import product
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 import torch
@@ -33,8 +33,10 @@ from torch_scatter import segment_coo, segment_csr
 
 
 def pyg2_data_transform(data: Data):
-    # if we're on the new pyg (2.0 or later) and if the Data stored is in older formet
-    #, we need to convert the data to the new format
+    '''
+    if we're on the new pyg (2.0 or later) and if the Data stored is in older format  
+    we need to convert the data to the new format
+    '''
     if torch_geometric.__version__ >= "2.0" and "_store" not in data.__dict__:
         return Data(
             **{k: v for k, v in data.__dict__.items() if v is not None}
@@ -223,33 +225,8 @@ def add_edge_distance_to_graph(
     return batch
 
 
-def setup_experimental_imports(root_folder: str):
-    experimental_folder = os.path.join(root_folder, "../experimental/")
-    if os.path.exists(experimental_folder):
-        experimental_files = glob.glob(
-            experimental_folder + "**/*py",
-            recursive=True,
-        )
-        # Ignore certain directories within experimental
-        ignore_file = os.path.join(experimental_folder, ".ignore")
-        if os.path.exists(ignore_file):
-            ignored = []
-            with open(ignore_file) as f:
-                for line in f.read().splitlines():
-                    ignored += glob.glob(
-                        experimental_folder + line + "/**/*py", recursive=True
-                    )
-            for f in ignored:
-                experimental_files.remove(f)
-        for f in experimental_files:
-            splits = f.split(os.sep)
-            file_name = ".".join(splits[-splits[::-1].index("..") :])
-            module_name = file_name[: file_name.find(".py")]
-            importlib.import_module(module_name)
-
-
 # Copied from https://github.com/facebookresearch/mmf/blob/master/mmf/utils/env.py#L89.
-def setup_imports(absolute_imports: Optional[bool] = None):
+def setup_imports():
     from ocpmodels.common.registry import registry
 
     # First, check if imports are already setup
@@ -292,8 +269,28 @@ def setup_imports(absolute_imports: Optional[bool] = None):
                     "ocpmodels.%s.%s" % (key[1:], module_name)
                 )
 
-    if not absolute_imports:
-        setup_experimental_imports(root_folder)
+    experimental_folder = os.path.join(root_folder, "../experimental/")
+    if os.path.exists(experimental_folder):
+        experimental_files = glob.glob(
+            experimental_folder + "**/*py",
+            recursive=True,
+        )
+        # Ignore certain directories within experimental
+        ignore_file = os.path.join(experimental_folder, ".ignore")
+        if os.path.exists(ignore_file):
+            ignored = []
+            with open(ignore_file) as f:
+                for line in f.read().splitlines():
+                    ignored += glob.glob(
+                        experimental_folder + line + "/**/*py", recursive=True
+                    )
+            for f in ignored:
+                experimental_files.remove(f)
+        for f in experimental_files:
+            splits = f.split(os.sep)
+            file_name = ".".join(splits[-splits[::-1].index("..") :])
+            module_name = file_name[: file_name.find(".py")]
+            importlib.import_module(module_name)
 
     registry.register("imports_setup", True)
 
@@ -409,11 +406,11 @@ def build_config(args, args_override):
     config["submit"] = args.submit
     config["summit"] = args.summit
     # Distributed
-    config["distributed"] = args.distributed
     config["local_rank"] = args.local_rank
     config["distributed_port"] = args.distributed_port
     config["world_size"] = args.num_nodes * args.num_gpus
     config["distributed_backend"] = args.distributed_backend
+    config["noddp"] = args.no_ddp
 
     return config
 
@@ -762,12 +759,14 @@ def merge_dicts(dict1: dict, dict2: dict):
     This does not modify the input dictionaries (creates an internal copy).
     Additionally returns a list of detected duplicates.
     Adapted from https://github.com/TUM-DAML/seml/blob/master/seml/utils.py
+
     Parameters
     ----------
     dict1: dict
         First dict.
     dict2: dict
         Second dict. Values in dict2 will override values from dict1 in case they share the same key.
+
     Returns
     -------
     return_dict: dict


### PR DESCRIPTION
Resolves #366.

Data created in PyG>2 ends up getting converted again [here](https://github.com/Open-Catalyst-Project/ocp/blob/bfd2d62758896ee38132636c03fdce43df2e2fe7/ocpmodels/common/utils.py#L35-L42) resulting in an empty Data object. This PR only runs this method if PyG>2 wasn't used for data construction. The same logic is used directly from PyG to check if new vs. old data is being used - https://github.com/pyg-team/pytorch_geometric/blob/a8601aafd7fc52b87b3f85e86013e64cb7af3e2d/torch_geometric/data/data.py#L422-L427.

Thanks @AdeeshKolluru!