### PR TITLE
Load attached scale file

### DIFF
--- a/ocpmodels/models/gemnet/layers/scaling.py
+++ b/ocpmodels/models/gemnet/layers/scaling.py
@@ -6,12 +6,11 @@ LICENSE file in the root directory of this source tree.
 """
 
 import logging
+import os
 
 import torch
 
 from ..utils import read_value_json, update_json
-
-import os
 
 
 class AutomaticFit:
@@ -80,8 +79,14 @@ class AutomaticFit:
         Load variable from file or set to initial value of the variable.
         """
         value = None
-        if self.scale_file is not None and os.path.isfile(self.scale_file):
+        if (
+            self.scale_file is not None
+            and isinstance(self.scale_file, str)
+            and os.path.isfile(self.scale_file)
+        ):
             value = read_value_json(self.scale_file, self._name)
+        elif isinstance(self.scale_file, dict):
+            value = self.scale_file.get(self._name, None)
         else:
             logging.warning(
                 f"Scale file '{self.scale_file}' does not exist. "

--- a/ocpmodels/models/gemnet_gp/layers/scaling.py
+++ b/ocpmodels/models/gemnet_gp/layers/scaling.py
@@ -79,8 +79,14 @@ class AutomaticFit:
         Load variable from file or set to initial value of the variable.
         """
         value = None
-        if self.scale_file is not None and os.path.isfile(self.scale_file):
+        if (
+            self.scale_file is not None
+            and isinstance(self.scale_file, str)
+            and os.path.isfile(self.scale_file)
+        ):
             value = read_value_json(self.scale_file, self._name)
+        elif isinstance(self.scale_file, dict):
+            value = self.scale_file.get(self._name, None)
         else:
             logging.warning(
                 f"Scale file '{self.scale_file}' does not exist. "

--- a/ocpmodels/models/gemnet_oc/gemnet_oc.py
+++ b/ocpmodels/models/gemnet_oc/gemnet_oc.py
@@ -381,8 +381,11 @@ class GemNetOC(ScaledModule, BaseModel):
 
         # Load scaling factors
         if scale_file is not None:
-            if os.path.isfile(scale_file):
+            if isinstance(scale_file, str) and os.path.isfile(scale_file):
                 scales = torch.load(scale_file, map_location="cpu")
+                self.load_scales(scales)
+            elif isinstance(scale_file, dict):
+                scales = scale_file
                 self.load_scales(scales)
             else:
                 logging.error(

--- a/ocpmodels/models/painn/painn.py
+++ b/ocpmodels/models/painn/painn.py
@@ -131,9 +131,13 @@ class PaiNN(ScaledModule, BaseModel):
 
         # Load scaling factors
         if scale_file is not None:
-            if os.path.isfile(scale_file):
+            if isinstance(scale_file, str) and os.path.isfile(scale_file):
                 logging.info(f"Loading scaling factors from {scale_file}")
                 scales = torch.load(scale_file, map_location="cpu")
+                self.load_scales(scales)
+            elif isinstance(scale_file, dict):
+                logging.info("Loading scaling factors from checkpoint")
+                scales = scale_file
                 self.load_scales(scales)
             else:
                 logging.warning(


### PR DESCRIPTION
These changes simply allow checkpoints to be loaded that have the path to a scale_file replaced with the full scale file dictionary. It doesn't include any functionality for actually modifying the checkpoints to store scale files that way.

It is also still compatible with loading scale files from their path, it just checks to see if it is a path or a dictionary.