### PR TITLE
Bugfix: use correct otf_graph, cutoff, max_neighbors for GemNet-OC graphs

### DIFF
--- a/ocpmodels/models/base.py
+++ b/ocpmodels/models/base.py
@@ -30,17 +30,23 @@ class BaseModel(nn.Module):
         raise NotImplementedError
 
     def generate_graph(
-        self, data, otf_graph=None, cutoff=None, max_neighbors=None
+        self,
+        data,
+        cutoff=None,
+        max_neighbors=None,
+        use_pbc=None,
+        otf_graph=None,
     ):
-        otf_graph = otf_graph or self.otf_graph
         cutoff = cutoff or self.cutoff
         max_neighbors = max_neighbors or self.max_neighbors
+        use_pbc = use_pbc or self.use_pbc
+        otf_graph = otf_graph or self.otf_graph
 
         if not otf_graph:
             try:
                 edge_index = data.edge_index
 
-                if self.use_pbc:
+                if use_pbc:
                     cell_offsets = data.cell_offsets
                     neighbors = data.neighbors
 
@@ -50,7 +56,7 @@ class BaseModel(nn.Module):
                 )
                 otf_graph = True
 
-        if self.use_pbc:
+        if use_pbc:
             if otf_graph:
                 edge_index, cell_offsets, neighbors = radius_graph_pbc(
                     data, cutoff, max_neighbors

--- a/ocpmodels/models/gemnet_oc/gemnet_oc.py
+++ b/ocpmodels/models/gemnet_oc/gemnet_oc.py
@@ -906,7 +906,12 @@ class GemNetOC(ScaledModule, BaseModel):
             distance_vec,
             cell_offsets,
             num_neighbors,
-        ) = self.generate_graph(data)
+        ) = self.generate_graph(
+            data,
+            otf_graph=otf_graph,
+            cutoff=cutoff,
+            max_neighbors=max_neighbors,
+        )
         # These vectors actually point in the opposite direction.
         # But we want to use col as idx_t for efficient aggregation.
         edge_vector = -distance_vec / edge_dist[:, None]

--- a/ocpmodels/models/gemnet_oc/gemnet_oc.py
+++ b/ocpmodels/models/gemnet_oc/gemnet_oc.py
@@ -908,13 +908,14 @@ class GemNetOC(ScaledModule, BaseModel):
             num_neighbors,
         ) = self.generate_graph(
             data,
-            otf_graph=otf_graph,
             cutoff=cutoff,
             max_neighbors=max_neighbors,
+            otf_graph=otf_graph,
         )
         # These vectors actually point in the opposite direction.
         # But we want to use col as idx_t for efficient aggregation.
         edge_vector = -distance_vec / edge_dist[:, None]
+        cell_offsets = -cell_offsets  # a - c + offset
 
         graph = {
             "edge_index": edge_index,


### PR DESCRIPTION
Bug from #378 affecting all GemNet-OC training / inference runs.

[`otf_graph` is set](https://github.com/Open-Catalyst-Project/ocp/blob/main/ocpmodels/models/gemnet_oc/gemnet_oc.py#L901) but never used in `generate_graph`. [The function uses `self.otf_graph`](https://github.com/Open-Catalyst-Project/ocp/blob/main/ocpmodels/models/base.py#L33).

Same for other parameters `self.cutoff_aint`, `self.max_neighbors_aint`.