### PR TITLE
Load scaling factors from checkpoint if available

### DIFF
--- a/ocpmodels/models/gemnet_oc/gemnet_oc.py
+++ b/ocpmodels/models/gemnet_oc/gemnet_oc.py
@@ -401,8 +401,6 @@ class GemNetOC(ScaledModule, BaseModel):
             logging.warning(
                 "`scale_file` is set to `None`. "
                 "The model will use unit scaling factors. "
-                "If you're running a pretrained checkpoint, "
-                "this will likely lead to inaccurate predictions."
             )
 
     def set_cutoffs(self, cutoff, cutoff_qint, cutoff_aeaint, cutoff_aint):

--- a/ocpmodels/models/painn/painn.py
+++ b/ocpmodels/models/painn/painn.py
@@ -287,7 +287,7 @@ class PaiNN(ScaledModule, BaseModel):
 
             # Create indexing array
             edge_reorder_idx = repeat_blocks(
-                neighbors_per_image // 2,
+                torch.div(neighbors_per_image, 2, rounding_mode="floor"),
                 repeats=2,
                 continuous_indexing=True,
                 repeat_inc=edge_index_new.size(1),

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -441,6 +441,13 @@ class BaseTrainer(ABC):
             self.ema.load_state_dict(checkpoint["ema"])
         else:
             self.ema = None
+        if "scale_dict" in checkpoint and checkpoint["scale_dict"] is not None:
+            logging.info(
+                "Overwriting scaling factors with those loaded from checkpoint. "
+                "If you're generating predictions with a pretrained checkpoint, this is the correct behavior. "
+                "To disable this, delete `scale_dict` from the checkpoint. "
+            )
+            self.model.module.module.load_scales(checkpoint["scale_dict"])
 
         for key in checkpoint["normalizers"]:
             if key in self.normalizers:

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -447,7 +447,14 @@ class BaseTrainer(ABC):
                 "If you're generating predictions with a pretrained checkpoint, this is the correct behavior. "
                 "To disable this, delete `scale_dict` from the checkpoint. "
             )
-            self.model.module.module.load_scales(checkpoint["scale_dict"])
+            if isinstance(self.model, OCPDataParallel):
+                self.model.module.load_scales(checkpoint["scale_dict"])
+            elif isinstance(self.model, DistributedDataParallel):
+                self.model.module.module.load_scales(checkpoint["scale_dict"])
+            else:
+                raise NotImplementedError(
+                    f"Loading scaling factors not supported for type {type(self.model)}. "
+                )
 
         for key in checkpoint["normalizers"]:
             if key in self.normalizers:


### PR DESCRIPTION
PR to load checkpoints with scaling factors packaged within them. @brookwander is helping test this.

I've updated all released GemNet-OC and PaiNN checkpoint files to include scaling factors and not require a separate scale file.