### PR TITLE
Bugfix: use correct offset distances in DimeNet, DimeNet++

### DIFF
--- a/ocpmodels/models/base.py
+++ b/ocpmodels/models/base.py
@@ -74,6 +74,7 @@ class BaseModel(nn.Module):
 
             edge_index = out["edge_index"]
             edge_dist = out["distances"]
+            cell_offset_distances = out["offsets"]
             distance_vec = out["distance_vec"]
         else:
             if otf_graph:
@@ -91,9 +92,19 @@ class BaseModel(nn.Module):
             cell_offsets = torch.zeros(
                 edge_index.shape[1], 3, device=data.pos.device
             )
+            cell_offset_distances = torch.zeros_like(
+                cell_offsets, device=data.pos.device
+            )
             neighbors = compute_neighbors(data, edge_index)
 
-        return edge_index, edge_dist, distance_vec, cell_offsets, neighbors
+        return (
+            edge_index,
+            edge_dist,
+            distance_vec,
+            cell_offsets,
+            cell_offset_distances,
+            neighbors,
+        )
 
     @property
     def num_params(self):

--- a/ocpmodels/models/cgcnn.py
+++ b/ocpmodels/models/cgcnn.py
@@ -126,6 +126,7 @@ class CGCNN(BaseModel):
             distances,
             distance_vec,
             cell_offsets,
+            _,  # cell offset distances
             neighbors,
         ) = self.generate_graph(data)
 

--- a/ocpmodels/models/dimenet.py
+++ b/ocpmodels/models/dimenet.py
@@ -143,15 +143,24 @@ class DimeNetWrap(DimeNet, BaseModel):
         (
             edge_index,
             dist,
-            distance_vec,
-            offsets,
+            _,
+            cell_offsets,
             neighbors,
         ) = self.generate_graph(data)
 
         data.edge_index = edge_index
-        data.cell_offsets = offsets
+        data.cell_offsets = cell_offsets
         data.neighbors = neighbors
         j, i = edge_index
+
+        # Compute the offset distances.
+        cell = torch.repeat_interleave(data.cell, neighbors, dim=0)
+        offsets = (
+            data.cell_offsets.float()
+            .view(-1, 1, 3)
+            .bmm(cell.float())
+            .view(-1, 3)
+        )
 
         _, _, idx_i, idx_j, idx_k, idx_kj, idx_ji = self.triplets(
             edge_index,

--- a/ocpmodels/models/dimenet.py
+++ b/ocpmodels/models/dimenet.py
@@ -145,6 +145,7 @@ class DimeNetWrap(DimeNet, BaseModel):
             dist,
             _,
             cell_offsets,
+            offsets,
             neighbors,
         ) = self.generate_graph(data)
 
@@ -152,15 +153,6 @@ class DimeNetWrap(DimeNet, BaseModel):
         data.cell_offsets = cell_offsets
         data.neighbors = neighbors
         j, i = edge_index
-
-        # Compute the offset distances.
-        cell = torch.repeat_interleave(data.cell, neighbors, dim=0)
-        offsets = (
-            data.cell_offsets.float()
-            .view(-1, 1, 3)
-            .bmm(cell.float())
-            .view(-1, 3)
-        )
 
         _, _, idx_i, idx_j, idx_k, idx_kj, idx_ji = self.triplets(
             edge_index,

--- a/ocpmodels/models/dimenet_plus_plus.py
+++ b/ocpmodels/models/dimenet_plus_plus.py
@@ -389,15 +389,24 @@ class DimeNetPlusPlusWrap(DimeNetPlusPlus, BaseModel):
         (
             edge_index,
             dist,
-            distance_vec,
-            offsets,
+            _,
+            cell_offsets,
             neighbors,
         ) = self.generate_graph(data)
 
         data.edge_index = edge_index
-        data.cell_offsets = offsets
+        data.cell_offsets = cell_offsets
         data.neighbors = neighbors
         j, i = edge_index
+
+        # Compute the offset distances.
+        cell = torch.repeat_interleave(data.cell, neighbors, dim=0)
+        offsets = (
+            data.cell_offsets.float()
+            .view(-1, 1, 3)
+            .bmm(cell.float())
+            .view(-1, 3)
+        )
 
         _, _, idx_i, idx_j, idx_k, idx_kj, idx_ji = self.triplets(
             edge_index,

--- a/ocpmodels/models/dimenet_plus_plus.py
+++ b/ocpmodels/models/dimenet_plus_plus.py
@@ -391,6 +391,7 @@ class DimeNetPlusPlusWrap(DimeNetPlusPlus, BaseModel):
             dist,
             _,
             cell_offsets,
+            offsets,
             neighbors,
         ) = self.generate_graph(data)
 
@@ -398,15 +399,6 @@ class DimeNetPlusPlusWrap(DimeNetPlusPlus, BaseModel):
         data.cell_offsets = cell_offsets
         data.neighbors = neighbors
         j, i = edge_index
-
-        # Compute the offset distances.
-        cell = torch.repeat_interleave(data.cell, neighbors, dim=0)
-        offsets = (
-            data.cell_offsets.float()
-            .view(-1, 1, 3)
-            .bmm(cell.float())
-            .view(-1, 3)
-        )
 
         _, _, idx_i, idx_j, idx_k, idx_kj, idx_ji = self.triplets(
             edge_index,

--- a/ocpmodels/models/forcenet.py
+++ b/ocpmodels/models/forcenet.py
@@ -442,6 +442,7 @@ class ForceNet(BaseModel):
             edge_dist,
             edge_vec,
             cell_offsets,
+            _,  # cell offset distances
             neighbors,
         ) = self.generate_graph(data)
 

--- a/ocpmodels/models/gemnet/gemnet.py
+++ b/ocpmodels/models/gemnet/gemnet.py
@@ -433,6 +433,7 @@ class GemNetT(BaseModel):
             D_st,
             distance_vec,
             cell_offsets,
+            _,  # cell offset distances
             neighbors,
         ) = self.generate_graph(data)
         # These vectors actually point in the opposite direction.

--- a/ocpmodels/models/gemnet_gp/gemnet.py
+++ b/ocpmodels/models/gemnet_gp/gemnet.py
@@ -431,6 +431,7 @@ class GraphParallelGemNetT(BaseModel):
             D_st,
             distance_vec,
             cell_offsets,
+            _,  # cell offset distances
             neighbors,
         ) = self.generate_graph(data)
         # These vectors actually point in the opposite direction.

--- a/ocpmodels/models/gemnet_oc/gemnet_oc.py
+++ b/ocpmodels/models/gemnet_oc/gemnet_oc.py
@@ -903,6 +903,7 @@ class GemNetOC(ScaledModule, BaseModel):
             edge_dist,
             distance_vec,
             cell_offsets,
+            _,  # cell offset distances
             num_neighbors,
         ) = self.generate_graph(
             data,

--- a/ocpmodels/models/painn/painn.py
+++ b/ocpmodels/models/painn/painn.py
@@ -341,6 +341,7 @@ class PaiNN(ScaledModule, BaseModel):
             edge_dist,
             distance_vec,
             cell_offsets,
+            _,  # cell offset distances
             neighbors,
         ) = self.generate_graph(data)
 

--- a/ocpmodels/models/schnet.py
+++ b/ocpmodels/models/schnet.py
@@ -95,6 +95,7 @@ class SchNetWrap(SchNet, BaseModel):
             edge_weight,
             distance_vec,
             cell_offsets,
+            _,  # cell offset distances
             neighbors,
         ) = self.generate_graph(data)
 

--- a/ocpmodels/models/scn/scn.py
+++ b/ocpmodels/models/scn/scn.py
@@ -281,6 +281,7 @@ class SphericalChannelNetwork(BaseModel):
             edge_distance,
             edge_distance_vec,
             cell_offsets,
+            _,  # cell offset distances
             neighbors,
         ) = self.generate_graph(data)
 

--- a/ocpmodels/models/spinconv.py
+++ b/ocpmodels/models/spinconv.py
@@ -199,6 +199,7 @@ class spinconv(BaseModel):
             edge_distance,
             edge_distance_vec,
             cell_offsets,
+            _,  # cell offset distances
             neighbors,
         ) = self.generate_graph(data)
 


### PR DESCRIPTION
Bug from #378. DimeNet and DimeNet++ were [using offset indices instead of offset distances](https://github.com/Open-Catalyst-Project/ocp/blob/bbd02315601aaf12cd90a546eae6fcd2b15ef308/ocpmodels/models/dimenet_plus_plus.py#L413-L414).