### PR TITLE
Fix pre-empt recovery crash

### DIFF
--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -956,7 +956,9 @@ def new_trainer_context(*, config: Dict[str, Any], args: Namespace):
         assert task_cls is not None, "Task not found"
         task = task_cls(config)
         start_time = time.time()
-        ctx = _TrainingContext(config=original_config, task=task, trainer=trainer)
+        ctx = _TrainingContext(
+            config=original_config, task=task, trainer=trainer
+        )
         yield ctx
         distutils.synchronize()
         if distutils.is_master():

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -920,7 +920,8 @@ def new_trainer_context(*, config: Dict[str, Any], args: Namespace):
         trainer: "BaseTrainer"
 
     setup_logging()
-    config = copy.deepcopy(config)
+    original_config = config
+    config = copy.deepcopy(original_config)
 
     if args.distributed:
         distutils.setup(config)
@@ -955,7 +956,7 @@ def new_trainer_context(*, config: Dict[str, Any], args: Namespace):
         assert task_cls is not None, "Task not found"
         task = task_cls(config)
         start_time = time.time()
-        ctx = _TrainingContext(config=config, task=task, trainer=trainer)
+        ctx = _TrainingContext(config=original_config, task=task, trainer=trainer)
         yield ctx
         distutils.synchronize()
         if distutils.is_master():


### PR DESCRIPTION
The most recent addition of the `new_training_context` function introduced a rare crash that happens when training resumes from a pre-emption event (see stacktrace below). 
```
2022-09-17 16:30:23 (ERROR): Submitted job triggered an exception
Traceback (most recent call last):
  File "/private/home/abhshkdz/.conda/envs/ocp-dev-jun2/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/private/home/abhshkdz/.conda/envs/ocp-dev-jun2/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/private/home/abhshkdz/.conda/envs/ocp-dev-jun2/lib/python3.9/site-packages/submitit/core/_submit.py", line 11, in <module>
    submitit_main()
  File "/private/home/abhshkdz/.conda/envs/ocp-dev-jun2/lib/python3.9/site-packages/submitit/core/submission.py", line 72, in submitit_main
    process_job(args.folder)
  File "/private/home/abhshkdz/.conda/envs/ocp-dev-jun2/lib/python3.9/site-packages/submitit/core/submission.py", line 65, in process_job
    raise error
  File "/private/home/abhshkdz/.conda/envs/ocp-dev-jun2/lib/python3.9/site-packages/submitit/core/submission.py", line 54, in process_job
    result = delayed.result()
  File "/private/home/abhshkdz/.conda/envs/ocp-dev-jun2/lib/python3.9/site-packages/submitit/core/utils.py", line 133, in result
    self._result = self.function(*self.args, **self.kwargs)
  File "/private/home/abhshkdz/projects/ocp-modeling-dev/main.py", line 28, in __call__
    with new_trainer_context(args=args, config=config) as ctx:
  File "/private/home/abhshkdz/.conda/envs/ocp-dev-jun2/lib/python3.9/contextlib.py", line 119, in __enter__
    return next(self.gen)
  File "/private/home/abhshkdz/projects/ocp-modeling-dev/ocpmodels/common/utils.py", line 935, in new_trainer_context
    trainer = trainer_cls(
  File "/private/home/abhshkdz/projects/ocp-modeling-dev/ocpmodels/trainers/forces_trainer.py", line 88, in __init__
    super().__init__(
  File "/private/home/abhshkdz/projects/ocp-modeling-dev/ocpmodels/trainers/base_trainer.py", line 127, in __init__
    "model": model.pop("name"),
KeyError: 'name'
```

This is caused by the config object being modified in place during execution. Then, when submitit resubmits the job after pre-emption, it uses this modified config, which then causes errors. This PR fixes this issue.