### PR TITLE
fix ML-based relaxations calculator

### DIFF
--- a/ocpmodels/common/relaxation/ase_utils.py
+++ b/ocpmodels/common/relaxation/ase_utils.py
@@ -181,6 +181,7 @@ class OCPCalculator(Calculator):
     def calculate(self, atoms, properties, system_changes):
         Calculator.calculate(self, atoms, properties, system_changes)
         data_object = self.a2g.convert(atoms)
+        data_object.tags = torch.from_numpy(atoms.get_tags())
         batch = data_list_collater([data_object], otf_graph=True)
 
         predictions = self.trainer.predict(


### PR DESCRIPTION
To run a ML-based relaxation trajectory, we need to keep track of the tags. Currently, by line 183 (`data_object = self.a2g.convert(atoms)`) we lose information about the tags. Please, correct me if I'm wrong.