### PR TITLE
Replaces get_submodule with operator library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
 
   test_macos:
     macos:
-      xcode: "13.4.0"
+      xcode: "13.4.1"
     resource_class: large
     steps:
       - install_deps_macos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
 
   test_macos:
     macos:
-      xcode: "13.4.1"
+      xcode: "13.4.0"
     resource_class: large
     steps:
       - install_deps_macos

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -969,10 +969,12 @@ def new_trainer_context(*, config: Dict[str, Any], args: Namespace):
 
 
 def _resolve_scale_factor_submodule(model: nn.Module, name: str):
+    import operator
+
     from ocpmodels.modules.scaling.scale_factor import ScaleFactor
 
     try:
-        scale = model.get_submodule(name)
+        scale = operator.attrgetter(name)(model)
         if not isinstance(scale, ScaleFactor):
             return None
         return scale


### PR DESCRIPTION
`get_submodule` doesn't seem to work as expected [here](https://github.com/Open-Catalyst-Project/ocp/blob/main/ocpmodels/common/utils.py#L975), this could be due to our torch version.

On testing the previous code with OCPCalculator, I was getting key errors. This key error was due to the scale modules being `None` [here](https://github.com/Open-Catalyst-Project/ocp/blob/main/ocpmodels/common/utils.py#L992). This was due to the attribute error coming from `get_submodule`  [here](https://github.com/Open-Catalyst-Project/ocp/blob/main/ocpmodels/common/utils.py#L980). 