### PR TITLE
reduce macos resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
   test_macos:
     macos:
       xcode: "13.4.1"
-    resource_class: large
+    resource_class: medium
     steps:
       - install_deps_macos
       - run:


### PR DESCRIPTION
per - https://circleci.com/docs/using-macos#available-resource-classes, `large` resource class for mac is unsupported without a plan. Reduce to `medium` to get accompanying CI build to run. 