### PR TITLE
alt trainer identifier

### DIFF
--- a/ocpmodels/common/relaxation/ase_utils.py
+++ b/ocpmodels/common/relaxation/ase_utils.py
@@ -12,7 +12,6 @@ Environment (ASE)
 import copy
 import logging
 import os
-import warnings
 
 import torch
 import yaml

--- a/ocpmodels/common/relaxation/ase_utils.py
+++ b/ocpmodels/common/relaxation/ase_utils.py
@@ -118,7 +118,7 @@ class OCPCalculator(Calculator):
                 "config"
             ]
 
-            # Load the trainer based on the dataset used
+            # Load the trainer based on the task description
             if "forces" in config["task"]["description"]:
                 config["trainer"] = "forces"
             else:

--- a/ocpmodels/common/relaxation/ase_utils.py
+++ b/ocpmodels/common/relaxation/ase_utils.py
@@ -133,7 +133,7 @@ class OCPCalculator(Calculator):
                     logging.warning(
                         "Unable to identify OCP trainer, defaulting to `forces`. Specify the `trainer` argument into OCPCalculator if otherwise."
                     )
-            config["trainer"] = "forces"
+                    config["trainer"] = "forces"
 
         config["model_attributes"]["name"] = config.pop("model")
         config["model"] = config["model_attributes"]

--- a/ocpmodels/common/relaxation/ase_utils.py
+++ b/ocpmodels/common/relaxation/ase_utils.py
@@ -119,7 +119,7 @@ class OCPCalculator(Calculator):
             ]
 
             # Load the trainer based on the dataset used
-            if config["task"]["dataset"] == "trajectory_lmdb":
+            if "forces" in config["task"]["description"]:
                 config["trainer"] = "forces"
             else:
                 config["trainer"] = "energy"

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -124,6 +124,7 @@ class BaseTrainer(ABC):
         logger_name = logger if isinstance(logger, str) else logger["name"]
         self.config = {
             "task": task,
+            "trainer": "forces" if name == "s2ef" else "energy",
             "model": model.pop("name"),
             "model_attributes": model,
             "optim": optimizer,


### PR DESCRIPTION
OCPCalculator relied on the "dataset" type to classify energy/force trainer. This introduces bugs for the newer datasets (OC22) that started using the newer class - LmdbDataset.

Open to other options, but this does the trick that's also backwards compatible. 