### PR TITLE
OCPCalc edge cases

### DIFF
--- a/ocpmodels/common/relaxation/ase_utils.py
+++ b/ocpmodels/common/relaxation/ase_utils.py
@@ -108,6 +108,12 @@ class OCPCalculator(Calculator):
                         )
                         include_config = yaml.safe_load(open(path, "r"))
                         config.update(include_config)
+                if "scale_file" in config["model"]:
+                    scale_file_path = os.path.join(
+                        config_yml.split("configs")[0],
+                        config["model"]["scale_file"],
+                    )
+                    config["model"]["scale_file"] = scale_file_path
             else:
                 config = config_yml
             # Only keeps the train data that might have normalizer values

--- a/ocpmodels/common/relaxation/ase_utils.py
+++ b/ocpmodels/common/relaxation/ase_utils.py
@@ -134,8 +134,9 @@ class OCPCalculator(Calculator):
                     )
                     config["trainer"] = "forces"
 
-        config["model_attributes"]["name"] = config.pop("model")
-        config["model"] = config["model_attributes"]
+        if "model_attributes" in config:
+            config["model_attributes"]["name"] = config.pop("model")
+            config["model"] = config["model_attributes"]
 
         # Calculate the edge indices on the fly
         config["model"]["otf_graph"] = True

--- a/ocpmodels/common/relaxation/ase_utils.py
+++ b/ocpmodels/common/relaxation/ase_utils.py
@@ -138,6 +138,11 @@ class OCPCalculator(Calculator):
             config["model_attributes"]["name"] = config.pop("model")
             config["model"] = config["model_attributes"]
 
+        # for checkpoints with relaxation datasets defined, remove to avoid
+        # unnecesarily trying to load that dataset
+        if "relax_dataset" in config["task"]:
+            del config["task"]["relax_dataset"]
+
         # Calculate the edge indices on the fly
         config["model"]["otf_graph"] = True
 

--- a/ocpmodels/common/relaxation/ase_utils.py
+++ b/ocpmodels/common/relaxation/ase_utils.py
@@ -108,12 +108,6 @@ class OCPCalculator(Calculator):
                         )
                         include_config = yaml.safe_load(open(path, "r"))
                         config.update(include_config)
-                if "scale_file" in config["model"]:
-                    scale_file_path = os.path.join(
-                        config_yml.split("configs")[0],
-                        config["model"]["scale_file"],
-                    )
-                    config["model"]["scale_file"] = scale_file_path
             else:
                 config = config_yml
             # Only keeps the train data that might have normalizer values


### PR DESCRIPTION
Resolves the bug in `OCPCalculator` when `config_yml` and `checkpoint` are both fed - throws an error when trying to access `model_attributes`. Originally raised  https://discuss.opencatalystproject.org/t/ocpcalculator-ase/221/4

Edit - Some checkpoints that have `relax_dataset` specified, will also throw an error as the trainer will try to load that dataset. Remove that from the config as it's unneeded for the calculator. 