### PR TITLE
Use PBC configuration from ASE atoms objects

### DIFF
--- a/ocpmodels/common/relaxation/ase_utils.py
+++ b/ocpmodels/common/relaxation/ase_utils.py
@@ -179,6 +179,7 @@ class OCPCalculator(Calculator):
             r_forces=False,
             r_distances=False,
             r_edges=False,
+            r_pbc=True,
         )
 
     def load_checkpoint(self, checkpoint_path):

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -551,8 +551,6 @@ def radius_graph_pbc(
     batch_size = len(data.natoms)
 
     if hasattr(data, "pbc"):
-        data.pbc = torch.array(data.pbc)
-
         for i in range(2):
             if not torch.any(data.pbc[:, i]):
                 pbc[i] = False

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -545,10 +545,23 @@ def get_pbc_distances(
 
 
 def radius_graph_pbc(
-    data, radius, max_num_neighbors_threshold, pbc=[True, True, False]
+    data, radius, max_num_neighbors_threshold, pbc=[True, True, True]
 ):
     device = data.pos.device
     batch_size = len(data.natoms)
+
+    if hasattr(data, "pbc"):
+        data.pbc = np.array(data.pbc)
+
+        for i in range(2):
+            if not np.any(data.pbc[:, i]):
+                pbc[i] = False
+            elif np.all(data.pbc[:, i]):
+                pbc[i] = True
+            else:
+                raise RuntimeError(
+                    "Different structures in the batch have different PBC configurations. This is not currently supported."
+                )
 
     # position of the atoms
     atom_pos = data.pos

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -551,10 +551,11 @@ def radius_graph_pbc(
     batch_size = len(data.natoms)
 
     if hasattr(data, "pbc"):
-        for i in range(2):
-            if not torch.any(data.pbc[:, i]):
+        data.pbc = torch.atleast_2d(data.pbc)
+        for i in range(3):
+            if not torch.any(data.pbc[:, i]).item():
                 pbc[i] = False
-            elif torch.all(data.pbc[:, i]):
+            elif torch.all(data.pbc[:, i]).item():
                 pbc[i] = True
             else:
                 raise RuntimeError(

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -551,12 +551,12 @@ def radius_graph_pbc(
     batch_size = len(data.natoms)
 
     if hasattr(data, "pbc"):
-        data.pbc = np.array(data.pbc)
+        data.pbc = torch.array(data.pbc)
 
         for i in range(2):
-            if not np.any(data.pbc[:, i]):
+            if not torch.any(data.pbc[:, i]):
                 pbc[i] = False
-            elif np.all(data.pbc[:, i]):
+            elif torch.all(data.pbc[:, i]):
                 pbc[i] = True
             else:
                 raise RuntimeError(

--- a/ocpmodels/preprocessing/atoms_to_graphs.py
+++ b/ocpmodels/preprocessing/atoms_to_graphs.py
@@ -187,7 +187,7 @@ class AtomsToGraphs:
                         fixed_idx[constraint.index] = 1
             data.fixed = fixed_idx
         if self.r_pbc:
-            data.pbc = atoms.pbc
+            data.pbc = torch.tensor(atoms.pbc)
 
         return data
 

--- a/ocpmodels/preprocessing/atoms_to_graphs.py
+++ b/ocpmodels/preprocessing/atoms_to_graphs.py
@@ -69,6 +69,7 @@ class AtomsToGraphs:
         r_distances=False,
         r_edges=True,
         r_fixed=True,
+        r_pbc=False,
     ):
         self.max_neigh = max_neigh
         self.radius = radius
@@ -77,6 +78,7 @@ class AtomsToGraphs:
         self.r_distances = r_distances
         self.r_fixed = r_fixed
         self.r_edges = r_edges
+        self.r_pbc = r_pbc
 
     def _get_neighbors_pymatgen(self, atoms):
         """Preforms nearest neighbor search and returns edge index, distances,
@@ -178,6 +180,8 @@ class AtomsToGraphs:
                     if isinstance(constraint, FixAtoms):
                         fixed_idx[constraint.index] = 1
             data.fixed = fixed_idx
+        if self.r_pbc:
+            data.pbc = atoms.pbc
 
         return data
 

--- a/ocpmodels/preprocessing/atoms_to_graphs.py
+++ b/ocpmodels/preprocessing/atoms_to_graphs.py
@@ -45,8 +45,11 @@ class AtomsToGraphs:
         r_forces (bool): Return the forces with other properties. Default is False, so the forces will not be returned.
         r_distances (bool): Return the distances with other properties.
         Default is False, so the distances will not be returned.
+        r_edges (bool): Return interatomic edges with other properties. Default is True, so energy will be returned.
         r_fixed (bool): Return a binary vector with flags for fixed (1) vs free (0) atoms.
         Default is True, so the fixed indices will be returned.
+        r_pbc (bool): Return the periodic boundary conditions with other properties.
+        Default is False, so the periodic boundary conditions will not be returned.
 
     Attributes:
         max_neigh (int): Maximum number of neighbors to consider.
@@ -55,8 +58,11 @@ class AtomsToGraphs:
         r_forces (bool): Return the forces with other properties. Default is False, so the forces will not be returned.
         r_distances (bool): Return the distances with other properties.
         Default is False, so the distances will not be returned.
+        r_edges (bool): Return interatomic edges with other properties. Default is True, so energy will be returned.
         r_fixed (bool): Return a binary vector with flags for fixed (1) vs free (0) atoms.
         Default is True, so the fixed indices will be returned.
+        r_pbc (bool): Return the periodic boundary conditions with other properties.
+        Default is False, so the periodic boundary conditions will not be returned.
 
     """
 
@@ -130,8 +136,8 @@ class AtomsToGraphs:
             atoms (ase.atoms.Atoms): An ASE atoms object.
 
         Returns:
-            data (torch_geometric.data.Data): A torch geometic data object with edge_index, positions, atomic_numbers,
-            and optionally, energy, forces, and distances.
+            data (torch_geometric.data.Data): A torch geometic data object with positions, atomic_numbers, tags,
+            and optionally, energy, forces, distances, edges, and periodic boundary conditions.
             Optional properties can included by setting r_property=True when constructing the class.
         """
 

--- a/ocpmodels/preprocessing/atoms_to_graphs.py
+++ b/ocpmodels/preprocessing/atoms_to_graphs.py
@@ -45,7 +45,7 @@ class AtomsToGraphs:
         r_forces (bool): Return the forces with other properties. Default is False, so the forces will not be returned.
         r_distances (bool): Return the distances with other properties.
         Default is False, so the distances will not be returned.
-        r_edges (bool): Return interatomic edges with other properties. Default is True, so energy will be returned.
+        r_edges (bool): Return interatomic edges with other properties. Default is True, so edges will be returned.
         r_fixed (bool): Return a binary vector with flags for fixed (1) vs free (0) atoms.
         Default is True, so the fixed indices will be returned.
         r_pbc (bool): Return the periodic boundary conditions with other properties.
@@ -58,7 +58,7 @@ class AtomsToGraphs:
         r_forces (bool): Return the forces with other properties. Default is False, so the forces will not be returned.
         r_distances (bool): Return the distances with other properties.
         Default is False, so the distances will not be returned.
-        r_edges (bool): Return interatomic edges with other properties. Default is True, so energy will be returned.
+        r_edges (bool): Return interatomic edges with other properties. Default is True, so edges will be returned.
         r_fixed (bool): Return a binary vector with flags for fixed (1) vs free (0) atoms.
         Default is True, so the fixed indices will be returned.
         r_pbc (bool): Return the periodic boundary conditions with other properties.


### PR DESCRIPTION
This PR is intended to address Issue #428 which relates to the handling of PBC in OCPCalculator. Previously, #394 allowed radius_graph_pbc to support all possible PBC configurations, but this option was not accessible to users.

Summary of changes:
- AtomsToGraphs can optionally return the PBC configuration of the ASE atoms object (off by default)
- OCPCalculator enables this option
- radius_graph_pbc will check if the PBC configuration is included in the data object. If yes, it will use that configuration. Otherwise, it will now default to [True, True, True].

Because AtomsToGraphs is widely used (constructing LMDBs, etc.), this implementation should enable some flexible PBC options for both training and inference. 

Different PBC configurations for different structures in the same batch is not currently supported.