### PR TITLE
Upgrades to pytorch 1.13, cuda 11.6, pyg 2.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,14 +31,11 @@ commands:
               conda config --set always_yes yes --set auto_update_conda false
               # Update conda
               conda update conda
-              conda install mamba -n base -c conda-forge
               # Install ocp conda env
-              conda create --name ocp-models --clone base
               source /home/circleci/miniconda/etc/profile.d/conda.sh
-              conda activate ocp-models
               conda install -c conda-forge conda-merge
               conda-merge env.common.yml env.cpu.yml > env.yml
-              mamba env update -n ocp-models --file env.yml
+              conda env create -f env.yml
               pip install pytest-cov==3.0.0
             fi
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  codecov: codecov/codecov@3.1.1
+
 workflows:
   version: 2
   install_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,8 @@ commands:
               conda install -c conda-forge conda-merge
               conda-merge env.common.yml env.cpu.yml > env.yml
               conda env create -f env.yml
-              pip install pytest-cov==3.0.0
+              conda activate ocp-models
+              pip install pytest-cov==4.0.0
             fi
       - save_cache:
           paths:
@@ -90,7 +91,7 @@ jobs:
             conda activate ocp-models
             pip install -e .
             pre-commit install
-            pytest --cov-report=xml --cov=ocpmodels/ /home/circleci/project/tests
+            pytest --cov=ocpmodels/ /home/circleci/project/tests
       - codecov/upload:
           file: coverage.xml
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,5 @@
 version: 2.1
 
-orbs:
-  win: circleci/windows@2.4.0
-  codecov: codecov/codecov@3.1.1
-
 workflows:
   version: 2
   install_and_test:
@@ -11,7 +7,6 @@ workflows:
       - python_lint
       - test_ubuntu
       - test_macos
-      - test_windows
 
 commands:
   install_deps_ubuntu:
@@ -65,32 +60,6 @@ commands:
           paths:
             - /Users/distiller/miniconda3
           key: conda-macos-{{ checksum ".circleci/config.yml" }}-{{ checksum "env.common.yml" }}-{{ checksum "env.cpu.yml" }}
-  install_deps_windows:
-    steps:
-      - checkout
-      - restore_cache:
-          key: conda-windows-{{ checksum ".circleci/config.yml" }}-{{ checksum "env.common.yml" }}-{{ checksum "env.cpu.yml" }}
-      - run:
-          name: Install conda and environment
-          command: |
-            if (Test-Path -Path "C:\tools\miniconda3\envs\ocp-models"){
-              Write-Host "miniconda installed already."
-              C:\tools\miniconda3\Scripts\conda.exe init powershell
-            }
-            else {
-              choco install -y --no-progress miniconda3
-              C:\tools\miniconda3\Scripts\conda.exe init powershell
-              conda config --set always_yes yes --set auto_update_conda false
-              conda update -n base -c defaults conda
-              conda install -c conda-forge conda-merge
-              conda-merge env.common.yml env.cpu.yml | out-file env.yml -Encoding utf8
-              conda env create -f env.yml
-            }
-      - save_cache:
-          paths:
-            - C:\tools\miniconda3
-          key: conda-windows-{{ checksum ".circleci/config.yml" }}-{{ checksum "env.common.yml" }}-{{ checksum "env.cpu.yml" }}
-
 
 jobs:
   python_lint:
@@ -132,21 +101,6 @@ jobs:
           name: install ocp and run tests
           command: |
             source $HOME/miniconda3/bin/activate
-            conda activate ocp-models
-            pip install -e .
-            pre-commit install
-            pytest tests
-
-  test_windows:
-    executor:
-      name: win/default
-      size: large
-    steps:
-      - install_deps_windows
-      - run:
-          name: install ocp and run tests
-          command: |
-            C:\tools\miniconda3\Scripts\conda.exe activate
             conda activate ocp-models
             pip install -e .
             pre-commit install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
           name: Install conda and environment
           command: |
             if [ ! -d "/home/circleci/miniconda" ]; then
-              wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+              wget https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-Linux-x86_64.sh -O miniconda.sh
               bash miniconda.sh -b -p "$HOME"/miniconda
               source /home/circleci/miniconda/etc/profile.d/conda.sh
               conda activate base
@@ -29,12 +29,14 @@ commands:
               conda config --set always_yes yes --set auto_update_conda false
               # Update conda
               conda update conda
+              conda install mamba -n base -c conda-forge
               # Install ocp conda env
+              conda create --name ocp-models --clone base
               source /home/circleci/miniconda/etc/profile.d/conda.sh
+              conda activate ocp-models
               conda install -c conda-forge conda-merge
               conda-merge env.common.yml env.cpu.yml > env.yml
-              conda env create -f env.yml
-              conda activate ocp-models
+              mamba env update -n ocp-models --file env.yml
               pip install pytest-cov==4.0.0
             fi
       - save_cache:
@@ -52,13 +54,16 @@ commands:
             if [[ -d $HOME/miniconda3 ]] ; then
               echo "miniconda installed already."
             else
-              curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+              curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-MacOSX-x86_64.sh
               bash ./miniconda.sh -b
               source $HOME/miniconda3/bin/activate
               conda config --set always_yes yes --set auto_update_conda false
+              conda install mamba -n base -c conda-forge
+              conda create --name ocp-models --clone base
+              conda activate ocp-models
               conda install -c conda-forge conda-merge
               conda-merge env.common.yml env.cpu.yml > env.yml
-              conda env create -f env.yml
+              mamba env update -n ocp-models --file env.yml
             fi
       - save_cache:
           paths:
@@ -91,7 +96,7 @@ jobs:
             conda activate ocp-models
             pip install -e .
             pre-commit install
-            pytest --cov=ocpmodels/ /home/circleci/project/tests
+            pytest --cov-report=xml --cov=ocpmodels/ /home/circleci/project/tests
       - codecov/upload:
           file: coverage.xml
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,15 +17,15 @@ Check that you can invoke `conda-merge` by running `conda-merge -h`.
 
 ### GPU machines
 
-Instructions are for PyTorch 1.9.0, CUDA 10.2 specifically.
+Instructions are for PyTorch 1.13.1, CUDA 11.6 specifically.
 
 First, check that CUDA is in your `PATH` and `LD_LIBRARY_PATH`, e.g.
 ```bash
 $ echo $PATH | tr ':' '\n' | grep cuda
-/public/apps/cuda/10.2/bin
+/public/apps/cuda/11.6/bin
 
 $ echo $LD_LIBRARY_PATH | tr ':' '\n' | grep cuda
-/public/apps/cuda/10.2/lib64
+/public/apps/cuda/11.6/lib64
 ```
 
 The exact paths may differ on your system.
@@ -44,14 +44,6 @@ Finally, install the pre-commit hooks:
 pre-commit install
 ```
 
-#### Ampere GPUs
-
-NVIDIA Ampere cards require a CUDA version >= 11.1 to function properly, modify the lines [here](https://github.com/Open-Catalyst-Project/ocp/blob/master/env.gpu.yml#L6-L8) to
-```
-- cudatoolkit=11.1
-- -f https://pytorch-geometric.com/whl/torch-1.9.0+cu111.html
-```
-
 ### CPU-only machines
 
 Please skip the following if you completed the with-GPU installation from above.
@@ -60,18 +52,6 @@ Please skip the following if you completed the with-GPU installation from above.
 conda-merge env.common.yml env.cpu.yml > env.yml
 conda env create -f env.yml
 conda activate ocp-models
-pip install -e .
-pre-commit install
-```
-
-### Mac CPU-only machines
-
-Only run the following if installing on a CPU only machine running Mac OS X.
-
-```
-conda env create -f env.common.yml
-conda activate ocp-models
-MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ pip install torch-cluster torch-scatter torch-sparse torch-spline-conv -f https://pytorch-geometric.com/whl/torch-1.9.0+cpu.html
 pip install -e .
 pre-commit install
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,48 +1,42 @@
 ## Installation
 
-The easiest way to install prerequisites is via [conda](https://conda.io/docs/index.html).
+- We'll use `conda` to install dependencies and set up the environment.
+We recommend using the [Python 3.9 Miniconda installer](https://docs.conda.io/en/latest/miniconda.html#linux-installers).
+- After installing `conda`, install [`mamba`](https://mamba.readthedocs.io/en/latest/) to the base environment. `mamba` is a faster, drop-in replacement for `conda`:
+    ```bash
+    conda install mamba -n base -c conda-forge
+    ```
+- Also install `conda-merge` to the base environment:
+    ```bash
+    conda install conda-merge -n base -c conda-forge
+    ```
 
-After installing [conda](http://conda.pydata.org/), run the following commands
-to create a new [environment](https://conda.io/docs/user-guide/tasks/manage-environments.html)
-named `ocp-models` and install dependencies.
-
-### Pre-install step
-
-Install `conda-merge`:
-```bash
-pip install conda-merge
-```
-If you're using system `pip`, then you may want to add the `--user` flag to avoid using `sudo`.
-Check that you can invoke `conda-merge` by running `conda-merge -h`.
+Next, follow the instructions for [GPU](#gpu-machines) or [CPU](#cpu-only-machines) machines depending on your hardware to create a new environment named `ocp-models` and install dependencies.
 
 ### GPU machines
 
 Instructions are for PyTorch 1.13.1, CUDA 11.6 specifically.
 
-First, check that CUDA is in your `PATH` and `LD_LIBRARY_PATH`, e.g.
-```bash
-$ echo $PATH | tr ':' '\n' | grep cuda
-/public/apps/cuda/11.6/bin
+- First, check that CUDA is in your `PATH` and `LD_LIBRARY_PATH`, e.g.
+    ```bash
+    $ echo $PATH | tr ':' '\n' | grep cuda
+    /public/apps/cuda/11.6/bin
 
-$ echo $LD_LIBRARY_PATH | tr ':' '\n' | grep cuda
-/public/apps/cuda/11.6/lib64
-```
-
-The exact paths may differ on your system.
-
-Then install the dependencies:
-```bash
-conda-merge env.common.yml env.gpu.yml > env.yml
-conda env create -f env.yml
-```
-Activate the conda environment with `conda activate ocp-models`.
-
-Install this package with `pip install -e .`.
-
-Finally, install the pre-commit hooks:
-```bash
-pre-commit install
-```
+    $ echo $LD_LIBRARY_PATH | tr ':' '\n' | grep cuda
+    /public/apps/cuda/11.6/lib64
+    ```
+    The exact paths may differ on your system.
+- Then install the dependencies:
+    ```bash
+    conda-merge env.common.yml env.gpu.yml > env.yml
+    mamba env create -f env.yml
+    ```
+    Activate the conda environment with `conda activate ocp-models`.
+- Install the `ocp` package with `pip install -e .`.
+- Finally, install the pre-commit hooks:
+    ```bash
+    pre-commit install
+    ```
 
 ### CPU-only machines
 
@@ -50,7 +44,7 @@ Please skip the following if you completed the with-GPU installation from above.
 
 ```bash
 conda-merge env.common.yml env.cpu.yml > env.yml
-conda env create -f env.yml
+mamba env create -f env.yml
 conda activate ocp-models
 pip install -e .
 pre-commit install

--- a/env.common.yml
+++ b/env.common.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip
   - pre-commit
   - pyg=2.2.0
-  - pytest
+  - pytest=7.1.2
   - python-lmdb
   - python=3.9.*
   - pytorch=1.13.1

--- a/env.common.yml
+++ b/env.common.yml
@@ -16,9 +16,9 @@ dependencies:
   - setuptools
   - tqdm
   - pip:
-    - ase=3.21.1
-    - black=22.3.0
-    - pymatgen=2020.12.31
+    - ase==3.21.1
+    - black==22.3.0
+    - pymatgen==2020.12.31
     - Pillow
     - submitit
     - syrupy

--- a/env.common.yml
+++ b/env.common.yml
@@ -1,26 +1,25 @@
-name: ocp-models
 channels:
-  - pytorch
-  - pyg
+- pytorch
+- pyg
+- conda-forge
+- defaults
 dependencies:
-  - matplotlib
-  - numba
-  - pip
-  - pre-commit
-  - pyg=2.2.0
-  - pytest=7.1.2
-  - python-lmdb
-  - python=3.9.*
-  - pytorch=1.13.1
-  - pyyaml
-  - setuptools
-  - tqdm
-  - pip:
-    - ase==3.21.1
-    - black==22.3.0
-    - pymatgen==2020.12.31
-    - Pillow
-    - submitit
-    - syrupy
-    - tensorboard
-    - wandb
+- ase=3.21.1
+- black==22.3.0
+- matplotlib
+- numba
+- pip
+- pre-commit=2.10.*
+- pyg=2.2.0
+- pymatgen=2020.12.31
+- python=3.9.*
+- pytorch=1.13.1
+- pyyaml
+- tensorboard
+- tqdm
+- pytest
+- python-lmdb
+- submitit
+- syrupy
+- wandb
+name: ocp-models

--- a/env.common.yml
+++ b/env.common.yml
@@ -1,30 +1,26 @@
 name: ocp-models
 channels:
   - pytorch
-  - conda-forge
-  - defaults
+  - pyg
 dependencies:
-  - ase=3.21.*
-  - matplotlib=3.3.*
-  - pip
-  - pre-commit=2.10.*
-  - pymatgen=2020.12.31
-  - python=3.9.*
-  - pytorch=1.10.1
-  - pyyaml=5.4.*
-  - tensorboard=2.5.*
-  - tqdm=4.58.*
-  - sphinx
-  - nbsphinx
-  - pandoc
-  - black==22.3.0
+  - matplotlib
   - numba
+  - pip
+  - pre-commit
+  - pyg=2.2.0
+  - pytest
+  - python-lmdb
+  - python=3.9.*
+  - pytorch=1.13.1
+  - pyyaml
+  - setuptools
+  - tqdm
   - pip:
+    - ase=3.21.1
+    - black=22.3.0
+    - pymatgen=2020.12.31
     - Pillow
-    - git+https://github.com/pyg-team/pytorch_geometric.git@a7e6be4
-    - wandb
-    - lmdb==1.1.1
-    - pytest==6.2.2
     - submitit
-    - sphinx-rtd-theme
     - syrupy
+    - tensorboard
+    - wandb

--- a/env.cpu.yml
+++ b/env.cpu.yml
@@ -1,8 +1,2 @@
 dependencies:
   - cpuonly
-  - pip:
-    - -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
-    - torch-cluster
-    - torch-scatter
-    - torch-sparse
-    - torch-spline-conv

--- a/env.gpu.yml
+++ b/env.gpu.yml
@@ -1,12 +1,4 @@
 channels:
-  - pytorch
-  - conda-forge
-  - defaults
+  - nvidia
 dependencies:
-  - cudatoolkit=11.1
-  - pip:
-    - -f https://data.pyg.org/whl/torch-1.10.0+cu111.html
-    - torch-cluster
-    - torch-scatter
-    - torch-sparse
-    - torch-spline-conv
+  - pytorch-cuda=11.6

--- a/ocpmodels/models/schnet.py
+++ b/ocpmodels/models/schnet.py
@@ -75,6 +75,7 @@ class SchNetWrap(SchNet, BaseModel):
         self.cutoff = cutoff
         self.otf_graph = otf_graph
         self.max_neighbors = 50
+        self.reduce = readout
         super(SchNetWrap, self).__init__(
             hidden_channels=hidden_channels,
             num_filters=num_filters,
@@ -113,7 +114,7 @@ class SchNetWrap(SchNet, BaseModel):
             h = self.lin2(h)
 
             batch = torch.zeros_like(z) if batch is None else batch
-            energy = scatter(h, batch, dim=0, reduce=self.readout)
+            energy = scatter(h, batch, dim=0, reduce=self.reduce)
         else:
             energy = super(SchNetWrap, self).forward(z, pos, batch)
         return energy


### PR DESCRIPTION
- Upgrades to pytorch 1.13.1, cuda 11.6, pyg 2.2.0.
- ~Moves conda-forge packages to pip install.~ 
- Conda-only install using mamba (supersedes #336).
- Removes windows test (has turned out to be finicky to support).