### PR TITLE
Periodic table embedding strategy for unseen elements

### DIFF
--- a/ocpmodels/models/gemnet_oc/gemnet_oc.py
+++ b/ocpmodels/models/gemnet_oc/gemnet_oc.py
@@ -1357,3 +1357,5 @@ class GemNetOC(BaseModel):
     @property
     def num_params(self):
         return sum(p.numel() for p in self.parameters())
+
+    all_atomic_embedding_keys = ["atom_emb.embeddings.weight"]

--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -431,6 +431,50 @@ class BaseTrainer(ABC):
         else:
             new_dict = checkpoint["state_dict"]
 
+        # If the number of elements in the model embeddings has been expanded beyond
+        # that of the checkpoint, copy the checkpoint values into the start of the embeddings.
+        # For example, we may want to expand from 83 elements in an initial vector to the whole
+        # periodic table (118 elements)
+        if self.config["task"].get(
+            "expand_atomic_embeddings_from_checkpoint", False
+        ):
+            logging.info("Expanding atomic embeddings from the checkpoint!")
+            for base_key in registry.get_model_class(
+                self.config["model"]
+            ).all_atomic_embedding_keys:
+                key = mod_key_count * "module." + base_key
+                self.model.state_dict()[key][
+                    : new_dict[key].shape[0]
+                ] = new_dict[key]
+                new_dict[key] = self.model.state_dict()[key]
+
+        if "interpolate_atomic_embeddings" in self.config["task"]:
+            fitted_datasets = self.config["task"][
+                "interpolate_atomic_embeddings"
+            ].get("fitted_datasets", ["OC20", "OC22"])
+            additional_fitted_elements = self.config["task"][
+                "interpolate_atomic_embeddings"
+            ].get("additional_fitted_elements", None)
+            smoothing = self.config["task"][
+                "interpolate_atomic_embeddings"
+            ].get("smoothing", 0.0)
+            logging.info(
+                f"Interpolating atomic embeddings from an RBF kernel using datasets {fitted_datasets} and additional elements {additional_fitted_elements}!"
+            )
+
+            for base_key in registry.get_model_class(
+                self.config["model"]
+            ).all_atomic_embedding_keys:
+                key = mod_key_count * "module." + base_key
+                new_dict[key][:] = torch.tensor(
+                    interpolate_embeddings(
+                        new_dict[key],
+                        fitted_datasets,
+                        additional_fitted_elements,
+                        smoothing,
+                    )
+                ).to(self.device)
+
         strict = self.config["task"].get("strict_load", True)
         load_state_dict(self.model, new_dict, strict=strict)
 
@@ -794,3 +838,174 @@ class BaseTrainer(ABC):
 
             logging.info(f"Writing results to {full_path}")
             np.savez_compressed(full_path, **gather_results)
+
+
+def interpolate_embeddings(
+    checkpoint_atom_embeddings,
+    fitted_datasets=["OC20", "OC22"],
+    additional_fitted_elements=None,
+    smoothing=0,
+):
+    # checkpoint_atom_embedding is tensor of shape (N_elements, embedding_size)
+    # datasets is a list of strings that represent stanard OCP datasets that the checkpoint might
+    #       have been trained on. It is used to guess which elements should be trusted
+    # fitted_elements_list is an an additional list of elements that were fitted, perhaps in case the dataset
+    #       that the dataset that this was trained on was not OC20 or OC22
+
+    OC20_elements = [
+        "Pb",
+        "Cs",
+        "Nb",
+        "In",
+        "Ta",
+        "Sc",
+        "Ni",
+        "Ru",
+        "Fe",
+        "Au",
+        "Sb",
+        "As",
+        "Cu",
+        "Ir",
+        "Al",
+        "N",
+        "Rb",
+        "Hf",
+        "V",
+        "Ca",
+        "P",
+        "Sr",
+        "Na",
+        "S",
+        "Si",
+        "Zn",
+        "C",
+        "Cd",
+        "Ti",
+        "Co",
+        "Ge",
+        "Mo",
+        "H",
+        "Pt",
+        "Os",
+        "O",
+        "K",
+        "Tl",
+        "Ag",
+        "Y",
+        "Bi",
+        "Rh",
+        "Cl",
+        "Ga",
+        "W",
+        "Cr",
+        "Tc",
+        "Sn",
+        "B",
+        "Pd",
+        "Mn",
+        "Hg",
+        "Re",
+        "Te",
+        "Zr",
+        "Se",
+    ]
+    OC22_elements = [
+        "Pb",
+        "Nb",
+        "Cs",
+        "In",
+        "Ta",
+        "Sc",
+        "Ni",
+        "Fe",
+        "Ru",
+        "Au",
+        "Ba",
+        "Sb",
+        "Cu",
+        "Ir",
+        "As",
+        "Al",
+        "Be",
+        "N",
+        "Rb",
+        "V",
+        "Hf",
+        "Ca",
+        "Sr",
+        "Ce",
+        "Na",
+        "Cd",
+        "Si",
+        "Zn",
+        "Li",
+        "C",
+        "Ti",
+        "Ge",
+        "Mo",
+        "Co",
+        "Pt",
+        "Os",
+        "H",
+        "O",
+        "K",
+        "Tl",
+        "Ag",
+        "Y",
+        "Mg",
+        "Bi",
+        "Rh",
+        "Ga",
+        "W",
+        "Cr",
+        "Sn",
+        "Pd",
+        "Hg",
+        "Lu",
+        "Mn",
+        "Re",
+        "Te",
+        "Zr",
+        "Se",
+    ]
+
+    from pymatgen.core.periodic_table import Element
+    from scipy.interpolate import RBFInterpolator
+
+    # Get all of the elements we should trust in checkpoint_atom_embeddings
+    fitted_elements = set()
+    if "OC20" in fitted_datasets:
+        fitted_elements = fitted_elements.union(OC20_elements)
+    if "OC22" in fitted_datasets:
+        fitted_elements = fitted_elements.union(OC22_elements)
+    if additional_fitted_elements is not None:
+        fitted_elements = fitted_elements.union(additional_fitted_elements)
+    fitted_elements = [Element(i) for i in fitted_elements]
+
+    def determine_pseudo_row_group(el):
+        # From the from_row_and_group fn in pmg Element class
+        if 57 <= el.Z <= 71:
+            el_pseudorow = 8
+            el_pseudogroup = (el.Z - 54) % 32
+        elif 89 <= el.Z <= 103:
+            el_pseudorow = 9
+            el_pseudogroup = (el.Z - 54) % 32
+        else:
+            el_pseudorow = el.row
+            el_pseudogroup = el.group
+        return el_pseudorow, el_pseudogroup
+
+    all_elements = [
+        determine_pseudo_row_group(Element.from_Z(i))
+        for i in range(1, checkpoint_atom_embeddings.shape[0] + 1)
+    ]
+    interpolated_embeddings = RBFInterpolator(
+        [determine_pseudo_row_group(el) for el in fitted_elements],
+        checkpoint_atom_embeddings[
+            [el.Z - 1 for el in fitted_elements], :
+        ].cpu(),
+        smoothing=smoothing,
+    )(all_elements)
+
+    return interpolated_embeddings


### PR DESCRIPTION
This is a preliminary PR to add an interpolation for atomic number embeddings. For example, if a trained or pre-trained checkpoint has never seen a specific element before, the embeddings for that element are essentially random and unhelpful, but we would expect them to be correlated to embeddings of nearby elements. 

This implementation uses a simple RBF-based interpolation strategy from scipy, with the atomic row and group as input features. 

Every model will have separate atomic embeddings that might need to be updated, so an example of the necessary information has been added to the gemnet_oc model. Similar changes would be needed for every other model that might benefit from this interpolation. 