### PR TITLE
Relaxation storage optimizations

### DIFF
--- a/configs/s2ef/example.yml
+++ b/configs/s2ef/example.yml
@@ -57,6 +57,8 @@ task:
     alpha: 70.0
     # Directory to save out trajectories (.traj files) in.
     traj_dir: path/to/traj/directory
+  # Whether to save out the full trajectory or just the initial+final frames
+  save_full_traj: True                                                          # True or False
   # When set to true, uses "deterministic" CUDA scatter ops if available,
   # i.e. given the same input, leads to the same results. Default is false
   # since this can be significantly slower.

--- a/ocpmodels/common/relaxation/ml_relaxation.py
+++ b/ocpmodels/common/relaxation/ml_relaxation.py
@@ -20,6 +20,7 @@ def ml_relax(
     steps,
     fmax,
     relax_opt,
+    save_full_traj,
     device="cuda:0",
     transform=None,
     early_stop_batch=False,
@@ -36,6 +37,8 @@ def ml_relax(
             of the system is no bigger than fmax.
         relax_opt: str
             Optimizer and corresponding parameters to be used for structure relaxations.
+        save_full_traj: bool
+            Whether to save out the full ASE trajectory. If False, only save out initial and final frames.
     """
     batch = batch[0]
     ids = batch.sid
@@ -51,6 +54,7 @@ def ml_relax(
         damping=relax_opt.get("damping", 1.0),
         alpha=relax_opt.get("alpha", 70.0),
         device=device,
+        save_full_traj=save_full_traj,
         traj_dir=Path(traj_dir) if traj_dir is not None else None,
         traj_names=ids,
         early_stop_batch=early_stop_batch,

--- a/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
+++ b/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
@@ -97,7 +97,6 @@ class LBFGS:
         self.y = deque(maxlen=self.memory)
         self.rho = deque(maxlen=self.memory)
         self.r0 = self.f0 = None
-        # update_mask = torch.ones_like(self.batch.batch, device=self.device).bool()
 
         self.trajectories = None
         if self.traj_dir:

--- a/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
+++ b/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
@@ -101,6 +101,7 @@ class LBFGS:
                 ase.io.Trajectory(self.traj_dir / f"{name}.traj_tmp", mode="w")
                 for name in self.traj_names
             ]
+            # saves out the initial frame
             self.write(e0, f0, update_mask, trajectories)
 
         iteration = 0
@@ -118,11 +119,12 @@ class LBFGS:
             if trajectories is not None:
                 # Save out ASE atoms objects only if:
                 # - save_full=True, saving out all frames else,
-                # - iteration==0, saving out the initial frame
                 # - iteration==steps-1 or converged=True, saves out the converged/final frame, whichever comes first.
                 if self.save_full or converged or iteration == steps - 1:
                     self.write(e0, f0, update_mask, trajectories)
 
+            # update the mask only after the previous mask was used to
+            # determine whether to write.
             update_mask = _update_mask
 
         # GPU memory usage as per nvidia-smi seems to gradually build up as

--- a/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
+++ b/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
@@ -8,10 +8,11 @@ LICENSE file in the root directory of this source tree.
 import logging
 from collections import deque
 from pathlib import Path
+from typing import Deque, Optional
 
 import ase
 import torch
-from ase import Atoms
+from torch_geometric.data import Batch
 from torch_scatter import scatter
 
 from ocpmodels.common.relaxation.ase_utils import batch_to_atoms
@@ -21,8 +22,8 @@ from ocpmodels.common.utils import radius_graph_pbc
 class LBFGS:
     def __init__(
         self,
-        atoms: Atoms,
-        model,
+        batch: Batch,
+        model: "TorchCalc",
         maxstep=0.01,
         memory=100,
         damping=0.25,
@@ -34,122 +35,126 @@ class LBFGS:
         traj_names=None,
         early_stop_batch: bool = False,
     ):
-        self.atoms = atoms
+        self.batch = batch
         self.model = model
         self.maxstep = maxstep
         self.memory = memory
         self.damping = damping
         self.alpha = alpha
+        self.H0 = 1.0 / self.alpha
         self.force_consistent = force_consistent
         self.device = device
         self.save_full = save_full_traj
         self.traj_dir = traj_dir
         self.traj_names = traj_names
         self.early_stop_batch = early_stop_batch
+        self.otf_graph = model.model.model.module.otf_graph
         assert not self.traj_dir or (
             traj_dir and len(traj_names)
         ), "Trajectory names should be specified to save trajectories"
         logging.info("Step   Fmax(eV/A)")
 
-        self.model.update_graph(self.atoms)
+        if not self.otf_graph and "edge_index" not in batch:
+            self.model.update_graph(self.batch)
 
-    def get_forces(self, apply_constraint=True):
-        energy, forces = self.model.get_forces(self.atoms, apply_constraint)
+    def get_energy_and_forces(self, apply_constraint=True):
+        energy, forces = self.model.get_energy_and_forces(
+            self.batch, apply_constraint
+        )
         return energy, forces
 
-    def get_positions(self):
-        return self.atoms.pos
-
     def set_positions(self, update, update_mask):
-        r = self.get_positions()
         if not self.early_stop_batch:
             update = torch.where(update_mask.unsqueeze(1), update, 0.0)
-        self.atoms.pos = r + update.to(dtype=torch.float32)
-        self.model.update_graph(self.atoms)
+        self.batch.pos += update.to(dtype=torch.float32)
 
-    def check_convergence(
-        self, iteration, update_mask, forces, force_threshold
-    ):
-        if forces is None:
-            return False
+        if not self.otf_graph:
+            self.model.update_graph(self.batch)
+
+    def check_convergence(self, iteration, forces=None, energy=None):
+        if forces is None or energy is None:
+            energy, forces = self.get_energy_and_forces()
+            forces = forces.to(dtype=torch.float64)
+
         max_forces_ = scatter(
-            (forces**2).sum(axis=1).sqrt(), self.atoms.batch, reduce="max"
-        )
-        max_forces = max_forces_[self.atoms.batch]
-        update_mask = torch.logical_and(
-            update_mask, max_forces.ge(force_threshold)
+            (forces**2).sum(axis=1).sqrt(), self.batch.batch, reduce="max"
         )
         logging.info(
-            f"{iteration+1} "
+            f"{iteration} "
             + " ".join(f"{x:0.3f}" for x in max_forces_.tolist())
         )
-        return update_mask
+
+        # (batch_size) -> (nAtoms)
+        max_forces = max_forces_[self.batch.batch]
+
+        return max_forces.ge(self.fmax), energy, forces
 
     def run(self, fmax, steps):
-        s = deque(maxlen=self.memory)
-        y = deque(maxlen=self.memory)
-        rho = deque(maxlen=self.memory)
-        r0 = None
-        e0, f0 = self.get_forces()
-        H0 = 1.0 / self.alpha
-        update_mask = torch.ones_like(self.atoms.batch).bool().to(self.device)
+        self.fmax = fmax
+        self.steps = steps
 
-        trajectories = None
+        self.s = deque(maxlen=self.memory)
+        self.y = deque(maxlen=self.memory)
+        self.rho = deque(maxlen=self.memory)
+        self.r0 = self.f0 = None
+        # update_mask = torch.ones_like(self.batch.batch, device=self.device).bool()
+
+        self.trajectories = None
         if self.traj_dir:
             self.traj_dir.mkdir(exist_ok=True, parents=True)
-            trajectories = [
+            self.trajectories = [
                 ase.io.Trajectory(self.traj_dir / f"{name}.traj_tmp", mode="w")
                 for name in self.traj_names
             ]
-            # saves out the initial frame
-            self.write(e0, f0, update_mask, trajectories)
 
         iteration = 0
         converged = False
-        while iteration < steps - 1 and not converged:
-            r0, f0, e0 = self.step(
-                iteration, r0, f0, H0, rho, s, y, update_mask
-            )
-            _update_mask = self.check_convergence(
-                iteration, update_mask, f0, fmax
-            )
-            converged = torch.all(torch.logical_not(_update_mask))
+        while iteration < steps and not converged:
+            update_mask, energy, forces = self.check_convergence(iteration)
+            converged = torch.all(torch.logical_not(update_mask))
+
+            if self.trajectories is not None:
+                if (
+                    self.save_full
+                    or converged
+                    or iteration == steps - 1
+                    or iteration == 0
+                ):
+                    self.write(energy, forces, update_mask)
+
+            if not converged and iteration < steps - 1:
+                self.step(iteration, forces, update_mask)
+
             iteration += 1
-
-            if trajectories is not None:
-                # Save out ASE atoms objects only if:
-                # - save_full=True, saving out all frames else,
-                # - iteration==steps-1 or converged=True, saves out the converged/final frame, whichever comes first.
-                if self.save_full or converged or iteration == steps - 1:
-                    self.write(e0, f0, update_mask, trajectories)
-
-            # update the mask only after the previous mask was used to
-            # determine whether to write.
-            update_mask = _update_mask
 
         # GPU memory usage as per nvidia-smi seems to gradually build up as
         # batches are processed. This releases unoccupied cached memory.
         torch.cuda.empty_cache()
 
-        if trajectories is not None:
-            for traj in trajectories:
+        if self.trajectories is not None:
+            for traj in self.trajectories:
                 traj.close()
             for name in self.traj_names:
                 traj_fl = Path(self.traj_dir / f"{name}.traj_tmp", mode="w")
                 traj_fl.rename(traj_fl.with_suffix(".traj"))
 
-        self.atoms.y, self.atoms.force = self.get_forces(
+        self.batch.y, self.batch.force = self.get_energy_and_forces(
             apply_constraint=False
         )
-        return self.atoms
+        return self.batch
 
-    def step(self, iteration, r0, f0, H0, rho, s, y, update_mask):
+    def step(
+        self,
+        iteration: int,
+        forces: Optional[torch.Tensor],
+        update_mask: torch.Tensor,
+    ):
         def determine_step(dr):
             steplengths = torch.norm(dr, dim=1)
             longest_steps = scatter(
-                steplengths, self.atoms.batch, reduce="max"
+                steplengths, self.batch.batch, reduce="max"
             )
-            longest_steps = longest_steps[self.atoms.batch]
+            longest_steps = longest_steps[self.batch.batch]
             maxstep = longest_steps.new_tensor(self.maxstep)
             scale = (longest_steps + 1e-7).reciprocal() * torch.min(
                 longest_steps, maxstep
@@ -157,42 +162,53 @@ class LBFGS:
             dr *= scale.unsqueeze(1)
             return dr * self.damping
 
-        e, f = self.get_forces()
-        f = f.to(self.device, dtype=torch.float64)
-        r = self.atoms.pos.to(self.device, dtype=torch.float64)
+        if forces is None:
+            _, forces = self.get_energy_and_forces()
 
-        # Update s, y and rho
+        r = self.batch.pos.clone().to(dtype=torch.float64)
+
+        # Update s, y, rho
         if iteration > 0:
-            s0 = (r - r0).flatten()
-            y0 = -(f - f0).flatten()
-            s.append(s0)
-            y.append(y0)
-            rho.append(1.0 / torch.dot(y0, s0))
+            s0 = (r - self.r0).flatten()
+            self.s.append(s0)
+
+            y0 = -(forces - self.f0).flatten()
+            self.y.append(y0)
+
+            self.rho.append(1.0 / torch.dot(y0, s0))
 
         loopmax = min(self.memory, iteration)
-        alpha = f.new_empty(loopmax)
-        q = -f.flatten()
+        alpha = forces.new_empty(loopmax)
+        q = -forces.flatten()
 
         for i in range(loopmax - 1, -1, -1):
-            alpha[i] = rho[i] * torch.dot(s[i], q)
-            q -= alpha[i] * y[i]
-        z = H0 * q
+            alpha[i] = self.rho[i] * torch.dot(self.s[i], q)  # b
+            q -= alpha[i] * self.y[i]
+
+        z = self.H0 * q
         for i in range(loopmax):
-            beta = rho[i] * torch.dot(y[i], z)
-            z += s[i] * (alpha[i] - beta)
-        p = -z.reshape((-1, 3))  # descent direction
+            beta = self.rho[i] * torch.dot(self.y[i], z)
+            z += self.s[i] * (alpha[i] - beta)
+
+        # descent direction
+        p = -z.reshape((-1, 3))
         dr = determine_step(p)
         if torch.abs(dr).max() < 1e-7:
             # Same configuration again (maybe a restart):
             return
-        self.set_positions(dr, update_mask)
-        return r, f, e
 
-    def write(self, e0, f0, update_mask, trajectories):
-        self.atoms.y, self.atoms.force = e0, f0
-        atoms_objects = batch_to_atoms(self.atoms)
-        update_mask_ = torch.split(update_mask, self.atoms.natoms.tolist())
-        for atm, traj, mask in zip(atoms_objects, trajectories, update_mask_):
+        self.set_positions(dr, update_mask)
+
+        self.r0 = r
+        self.f0 = forces
+
+    def write(self, energy, forces, update_mask):
+        self.batch.y, self.batch.force = energy, forces
+        atoms_objects = batch_to_atoms(self.batch)
+        update_mask_ = torch.split(update_mask, self.batch.natoms.tolist())
+        for atm, traj, mask in zip(
+            atoms_objects, self.trajectories, update_mask_
+        ):
             if mask[0] or not self.save_full:
                 traj.write(atm)
 
@@ -202,7 +218,7 @@ class TorchCalc:
         self.model = model
         self.transform = transform
 
-    def get_forces(self, atoms, apply_constraint=True):
+    def get_energy_and_forces(self, atoms, apply_constraint=True):
         predictions = self.model.predict(
             atoms, per_image=False, disable_tqdm=True
         )

--- a/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
+++ b/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
@@ -48,7 +48,7 @@ class LBFGS:
         self.traj_dir = traj_dir
         self.traj_names = traj_names
         self.early_stop_batch = early_stop_batch
-        self.otf_graph = model.model.model.module.otf_graph
+        self.otf_graph = model.model._unwrapped_model.otf_graph
         assert not self.traj_dir or (
             traj_dir and len(traj_names)
         ), "Trajectory names should be specified to save trajectories"

--- a/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
+++ b/ocpmodels/common/relaxation/optimizers/lbfgs_torch.py
@@ -123,14 +123,8 @@ class LBFGS:
                 ):
                     self.atoms.y, self.atoms.force = e0, f0
                     atoms_objects = batch_to_atoms(self.atoms)
-                    update_mask_ = torch.split(
-                        update_mask, self.atoms.natoms.tolist()
-                    )
-                    for atm, traj, mask in zip(
-                        atoms_objects, trajectories, update_mask_
-                    ):
-                        if mask[0]:
-                            traj.write(atm)
+                    for atm, traj in zip(atoms_objects, trajectories):
+                        traj.write(atm)
 
             # Only take an optimization step if not converged and not at the
             # final frame.

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -682,6 +682,7 @@ class ForcesTrainer(BaseTrainer):
                 steps=self.config["task"].get("relaxation_steps", 200),
                 fmax=self.config["task"].get("relaxation_fmax", 0.0),
                 relax_opt=self.config["task"]["relax_opt"],
+                save_full_traj=self.config["task"].get("save_full_traj", True),
                 device=self.device,
                 transform=None,
             )


### PR DESCRIPTION
Makes the following changes to the way we save relaxations:

- ASE/VASP convention refers to the 0th step as being the initial atoms object, updates the logic to save out the initial frame and then run N-1 steps.
- Adds a flag to control what data gets saved during relaxations:
  - `save_full_traj=1` (default) saves every frame
  -  `save_full_traj=0` saves only the initial and final frame
- Cleans up the relaxation code pursuant to #440 

Storage usage on Val-ID (~25k systems):
`save_full_traj=1`: 32G
`save_full_traj=0`: 288MB


As a sanity check I ran OC20 Val-ID relaxations to compare performance:

Old: 0.3398710582458926 eV

New (`save_full_traj=1`): 0.33946821912398933 eV
New (`save_full_traj=0`): 0.3389780476024761 eV


Edit: Per the latest changes-  
Old: 0.3398710582458926 eV
New (`save_full_traj=1`): 0.3330330166265487 eV
New (`save_full_traj=0`): 0.3332381077699672 eV