### PR TITLE
Support dataset sharding

### DIFF
--- a/configs/s2ef/example.yml
+++ b/configs/s2ef/example.yml
@@ -49,6 +49,10 @@ task:
   # Path to initial structures to run relaxations on. Same as the IS2RE set.
   relax_dataset:
     src: data/is2re/all/test_id/data.lmdb
+    # To shard a dataset into smaller subsets, define the total_shards desired
+    # and the shard a particular process to see.
+    total_shards: 1                                                             # int (optional)
+    shard: 0                                                                    # int (optional)
   relax_opt:
     name: lbfgs
     maxstep: 0.04


### PR DESCRIPTION
When running inference, multiple 1 GPU jobs can often be faster than a multi-gpu/node job due to potential overhead and communication involved. 

This PR supports the availability to shard a defined dataset into appropriate chunks. A process launched with the following config will partition the dataset in 5 approximately equal chunks and only run on the 0th shard. 

```
relax_dataset:
   src: path/to/data
   shard: 0
   total_shards: 5
```

To run inference on the full dataset under this use case, 5 jobs must be launched with `shard` set from 0-4.

Benchmark:

GemNet-OC on 10k systems, averaged across 5 runs each.

GPUs | GPU-sec/RX
-- | --
1 | 6.84
8 | 9.65
64 | 11.23





