### PR TITLE
Warnings for missing scale files during validation

### DIFF
--- a/ocpmodels/trainers/base_trainer.py
+++ b/ocpmodels/trainers/base_trainer.py
@@ -633,7 +633,7 @@ class BaseTrainer(ABC):
 
     @torch.no_grad()
     def validate(self, split="val", disable_tqdm=False):
-        ensure_fitted(self._unwrapped_model)
+        ensure_fitted(self._unwrapped_model, warn=True)
 
         if distutils.is_master():
             logging.info(f"Evaluating on {split}.")


### PR DESCRIPTION
If running training without explicitly setting scale files, training will start and ensure_fitted will send warnings about unfitted scale parameters. However, during the validation step ensure_fitted throws hard errors about scale files being unfitted.

This tiny PR changes the validate step to only throw warnings in this scenario, similar to the training loop.