### PR TITLE
Improper OOM merge fix

### DIFF
--- a/ocpmodels/common/relaxation/ml_relaxation.py
+++ b/ocpmodels/common/relaxation/ml_relaxation.py
@@ -62,6 +62,7 @@ def ml_relax(
             damping=relax_opt.get("damping", 1.0),
             alpha=relax_opt.get("alpha", 70.0),
             device=device,
+            save_full_traj=save_full_traj,
             traj_dir=Path(traj_dir) if traj_dir is not None else None,
             traj_names=ids,
             early_stop_batch=early_stop_batch,


### PR DESCRIPTION
Looks like when https://github.com/Open-Catalyst-Project/ocp/pull/447 was merged it removed the definition of `save_full_traj`.