### PR TITLE
eSCN CPU support

### DIFF
--- a/ocpmodels/models/escn/escn.py
+++ b/ocpmodels/models/escn/escn.py
@@ -85,7 +85,7 @@ class eSCN(BaseModel):
         distance_function="gaussian",
         basis_width_scalar=1.0,
         distance_resolution=0.02,
-        show_timing_info=True,
+        show_timing_info=False,
     ):
         super().__init__()
 
@@ -204,20 +204,24 @@ class eSCN(BaseModel):
             )
 
         # Create a roughly evenly distributed point sampling of the sphere for the output blocks
-        self.sphere_points = CalcSpherePoints(
-            self.num_sphere_samples, self.device
-        ).detach()
+        self.sphere_points = nn.Parameter(
+            CalcSpherePoints(self.num_sphere_samples), requires_grad=False
+        )
 
         # For each spherical point, compute the spherical harmonic coefficient weights
         self.sphharm_weights = []
         for i in range(self.num_resolutions):
             self.sphharm_weights.append(
-                o3.spherical_harmonics(
-                    torch.arange(0, self.lmax_list[i] + 1).tolist(),
-                    self.sphere_points,
-                    False,
-                ).detach()
+                nn.Parameter(
+                    o3.spherical_harmonics(
+                        torch.arange(0, self.lmax_list[i] + 1).tolist(),
+                        self.sphere_points,
+                        False,
+                    ),
+                    requires_grad=False,
+                )
             )
+        self.sphharm_weights = nn.ParameterList(self.sphharm_weights)
 
     @conditional_grad(torch.enable_grad())
     def forward(self, data):

--- a/ocpmodels/models/scn/sampling.py
+++ b/ocpmodels/models/scn/sampling.py
@@ -11,7 +11,7 @@ import torch
 ### Methods for sample points on a sphere
 
 
-def CalcSpherePoints(num_points, device):
+def CalcSpherePoints(num_points, device="cpu"):
     goldenRatio = (1 + 5**0.5) / 2
     i = torch.arange(num_points, device=device).view(-1, 1)
     theta = 2 * math.pi * i / goldenRatio


### PR DESCRIPTION
Resolves #461 

One of the efficiency improvements eSCN made is that it computes spherical harmonic weights [once in the initialization](https://github.com/Open-Catalyst-Project/ocp/blob/ad06ac85b943edcb596905241487ca8e63e34c2b/ocpmodels/models/escn/escn.py#L206-L220.) that gets used throughout training. This is contrary to how SCN originally did it, where it computed them at [each forward pass](https://github.com/Open-Catalyst-Project/ocp/blob/ad06ac85b943edcb596905241487ca8e63e34c2b/ocpmodels/models/scn/scn.py#L390-L395).

The way it's currently setup, however, is it hardcodes a device in the model `__init__`  https://github.com/Open-Catalyst-Project/ocp/blob/ad06ac85b943edcb596905241487ca8e63e34c2b/ocpmodels/models/escn/escn.py#L121 which conflicts with the true device the repo is operating under - https://github.com/Open-Catalyst-Project/ocp/blob/ad06ac85b943edcb596905241487ca8e63e34c2b/ocpmodels/trainers/base_trainer.py#L81-L86 Specifically, if you specify to run on CPU and the machine has a GPU, `self.device` in eSCN will be the cuda device. 

To resolve this we should convert these explicitly to `Parameter` or `Module` objects, which are properly moved to the correct device [here](https://github.com/Open-Catalyst-Project/ocp/blob/main/ocpmodels/trainers/base_trainer.py#L378).

This does break the existing checkpoints, I will modify them accordingly to fit this new structure.