### PR TITLE
Allow models to include degenerate edges

### DIFF
--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from functools import wraps
 from itertools import product
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Callable
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional,
 
 import numpy as np
 import torch

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from functools import wraps
 from itertools import product
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional,
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional
 
 import numpy as np
 import torch

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -723,7 +723,7 @@ def get_max_neighbors_mask(
     index,
     atom_distance,
     max_num_neighbors_threshold,
-    break_ties_heuristically = True,
+    break_ties_heuristically = False,
 ):
     """
     Give a mask that filters out edges so that each atom has at most
@@ -789,7 +789,7 @@ def get_max_neighbors_mask(
         num_included = max_num_neighbors_threshold
         
     else:
-        effective_cutoff = distance_sort[:, max_num_neighbors_threshold]
+        effective_cutoff = distance_sort[:, max_num_neighbors_threshold] + 0.01
         is_included = torch.le(distance_sort.T, effective_cutoff)
         num_included = torch.max(torch.sum(is_included, dim=0))
 

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -724,8 +724,8 @@ def get_max_neighbors_mask(
     atom_distance,
     max_num_neighbors_threshold,
     enforce_max_strictly = False,
-    enforce_symmetry = True,
-    enforce_symmetry_pooling_func: Callable = torch.max,
+    global_cutoff = True,
+    global_cutoff_pooling_func: Callable = torch.max,
 ):
     """
     Give a mask that filters out edges so that each atom has at most
@@ -737,9 +737,10 @@ def get_max_neighbors_mask(
     example, bulk formation energies which are not invariant to
     unit cell choice.
     
-    Enforcing symmetry will set a global cutoff that will lead to each 
-    atom having approximately the desired number of edges. This ensures 
-    that for all returned edges i->j, j->i is also returned.
+    If enabled, a global cutoff that leads to each atom having 
+    approximately the desired number of edges will be chosen. The 
+    primary purpose is to ensure  that for all returned 
+    edges i->j, j->i is also returned (symmetry enforcement).
     You can supply a callable that specifies how the list of effective
     cutoffs for each atom will be turned into one global cutoff.
     Reasonable callables may include: torch.min, torch.max, torch.mean
@@ -809,8 +810,8 @@ def get_max_neighbors_mask(
         
     else:
         effective_cutoff = distance_sort[:, max_num_neighbors_threshold] + 0.01
-        if enforce_symmetry:
-            effective_cutoff = enforce_symmetry_pooling_func(effective_cutoff)
+        if global_cutoff:
+            effective_cutoff = global_cutoff_pooling_func(effective_cutoff)
         is_included = torch.le(distance_sort.T, effective_cutoff)
         
         # Set all undesired edges to infinite length to be removed later

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -547,10 +547,10 @@ def get_pbc_distances(
 
 
 def radius_graph_pbc(
-    data, 
+    data,
     radius,
     max_num_neighbors_threshold,
-    enforce_max_neighbors_strictly = False,
+    enforce_max_neighbors_strictly=False,
     pbc=[True, True, True],
 ):
     device = data.pos.device
@@ -706,7 +706,7 @@ def radius_graph_pbc(
         index=index1,
         atom_distance=atom_distance_sqr,
         max_num_neighbors_threshold=max_num_neighbors_threshold,
-        enforce_max_strictly = enforce_max_neighbors_strictly,
+        enforce_max_strictly=enforce_max_neighbors_strictly,
     )
 
     if not torch.all(mask_num_neighbors):
@@ -728,24 +728,24 @@ def get_max_neighbors_mask(
     index,
     atom_distance,
     max_num_neighbors_threshold,
-    degeneracy_tolerance = 0.01,
-    enforce_max_strictly = False,
+    degeneracy_tolerance=0.01,
+    enforce_max_strictly=False,
 ):
     """
     Give a mask that filters out edges so that each atom has at most
     `max_num_neighbors_threshold` neighbors.
     Assumes that `index` is sorted.
-    
+
     Enforcing the max strictly can force the arbitrary choice between
-    degenerate edges. This can lead to undesired behaviors; for 
+    degenerate edges. This can lead to undesired behaviors; for
     example, bulk formation energies which are not invariant to
     unit cell choice.
-    
+
     A degeneracy tolerance can help prevent sudden changes in edge
     existence from small changes in atom position, for example,
     rounding errors, slab relaxation, temperature, etc.
     """
-    
+
     device = natoms.device
     num_atoms = natoms.sum()
 
@@ -797,32 +797,37 @@ def get_max_neighbors_mask(
 
     # Sort neighboring atoms based on distance
     distance_sort, index_sort = torch.sort(distance_sort, dim=1)
-    
+
     # Select the max_num_neighbors_threshold neighbors that are closest
     if enforce_max_strictly:
         distance_sort = distance_sort[:, :max_num_neighbors_threshold]
         index_sort = index_sort[:, :max_num_neighbors_threshold]
         max_num_included = max_num_neighbors_threshold
-        
+
     else:
-        effective_cutoff = distance_sort[:, max_num_neighbors_threshold] + degeneracy_tolerance
+        effective_cutoff = (
+            distance_sort[:, max_num_neighbors_threshold]
+            + degeneracy_tolerance
+        )
         is_included = torch.le(distance_sort.T, effective_cutoff)
-        
+
         # Set all undesired edges to infinite length to be removed later
         distance_sort[~is_included.T] = np.inf
-        
+
         # Subselect tensors for efficiency
         num_included_per_atom = torch.sum(is_included, dim=0)
         max_num_included = torch.max(num_included_per_atom)
         distance_sort = distance_sort[:, :max_num_included]
         index_sort = index_sort[:, :max_num_included]
-        
+
         # Recompute the number of neighbors
         num_neighbors_thresholded = num_neighbors.clamp(
             max=num_included_per_atom
         )
-        
-        num_neighbors_image = segment_csr(num_neighbors_thresholded, image_indptr)
+
+        num_neighbors_image = segment_csr(
+            num_neighbors_thresholded, image_indptr
+        )
 
     # Offset index_sort so that it indexes into index
     index_sort = index_sort + index_neighbor_offset.view(-1, 1).expand(

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -748,7 +748,7 @@ def get_max_neighbors_mask(
     Strictly enforcing the maximum and symmetry together is unsupported.
     """
     
-    assert not (enforce_max_strictly and enforce_symmetry)
+    assert not (enforce_max_strictly and global_cutoff)
     
     device = natoms.device
     num_atoms = natoms.sum()

--- a/ocpmodels/models/base.py
+++ b/ocpmodels/models/base.py
@@ -36,11 +36,21 @@ class BaseModel(nn.Module):
         max_neighbors=None,
         use_pbc=None,
         otf_graph=None,
+        enforce_max_neighbors_strictly=None,
     ):
         cutoff = cutoff or self.cutoff
         max_neighbors = max_neighbors or self.max_neighbors
         use_pbc = use_pbc or self.use_pbc
         otf_graph = otf_graph or self.otf_graph
+        
+        if enforce_max_neighbors_strictly is not None:
+            pass
+        elif hasattr(self, 'enforce_max_neighbors_strictly'):
+            # Not all models will have this attribute
+            enforce_max_neighbors_strictly = enforce_max_neighbors_strictly or self.enforce_max_neighbors_strictly
+        else:
+            # Default to old behavior
+            enforce_max_neighbors_strictly = True
 
         if not otf_graph:
             try:
@@ -59,7 +69,10 @@ class BaseModel(nn.Module):
         if use_pbc:
             if otf_graph:
                 edge_index, cell_offsets, neighbors = radius_graph_pbc(
-                    data, cutoff, max_neighbors
+                    data,
+                    cutoff,
+                    max_neighbors,
+                    enforce_max_neighbors_strictly,
                 )
 
             out = get_pbc_distances(

--- a/ocpmodels/models/base.py
+++ b/ocpmodels/models/base.py
@@ -42,12 +42,14 @@ class BaseModel(nn.Module):
         max_neighbors = max_neighbors or self.max_neighbors
         use_pbc = use_pbc or self.use_pbc
         otf_graph = otf_graph or self.otf_graph
-        
+
         if enforce_max_neighbors_strictly is not None:
             pass
-        elif hasattr(self, 'enforce_max_neighbors_strictly'):
+        elif hasattr(self, "enforce_max_neighbors_strictly"):
             # Not all models will have this attribute
-            enforce_max_neighbors_strictly = enforce_max_neighbors_strictly or self.enforce_max_neighbors_strictly
+            enforce_max_neighbors_strictly = (
+                self.enforce_max_neighbors_strictly
+            )
         else:
             # Default to old behavior
             enforce_max_neighbors_strictly = True

--- a/ocpmodels/models/gemnet_oc/gemnet_oc.py
+++ b/ocpmodels/models/gemnet_oc/gemnet_oc.py
@@ -862,7 +862,7 @@ class GemNetOC(BaseModel):
                 index=subgraph["edge_index"][1],
                 atom_distance=subgraph["distance"],
                 max_num_neighbors_threshold=max_neighbors,
-                enforce_max_strictly = self.enforce_max_neighbors_strictly,
+                enforce_max_strictly=self.enforce_max_neighbors_strictly,
             )
             if not torch.all(edge_mask):
                 subgraph["edge_index"] = subgraph["edge_index"][:, edge_mask]

--- a/ocpmodels/models/gemnet_oc/gemnet_oc.py
+++ b/ocpmodels/models/gemnet_oc/gemnet_oc.py
@@ -142,7 +142,9 @@ class GemNetOC(BaseModel):
     max_neighbors_aint: int
         Maximum number of atom-to-atom interactions per atom.
         Optional. Uses maximum of all other neighbors per default.
-
+    enforce_max_neighbors_strictly: bool
+        When subselected edges based on max_neighbors args, arbitrarily
+        select amongst degenerate edges to have exactly the correct number.
     rbf: dict
         Name and hyperparameters of the radial basis function.
     rbf_spherical: dict
@@ -221,6 +223,7 @@ class GemNetOC(BaseModel):
         max_neighbors_qint: Optional[int] = None,
         max_neighbors_aeaint: Optional[int] = None,
         max_neighbors_aint: Optional[int] = None,
+        enforce_max_neighbors_strictly: bool = True,
         rbf: dict = {"name": "gaussian"},
         rbf_spherical: Optional[dict] = None,
         envelope: dict = {"name": "polynomial", "exponent": 5},
@@ -265,6 +268,7 @@ class GemNetOC(BaseModel):
             max_neighbors_aeaint,
             max_neighbors_aint,
         )
+        self.enforce_max_neighbors_strictly = enforce_max_neighbors_strictly
         self.use_pbc = use_pbc
 
         self.direct_forces = direct_forces
@@ -858,6 +862,7 @@ class GemNetOC(BaseModel):
                 index=subgraph["edge_index"][1],
                 atom_distance=subgraph["distance"],
                 max_num_neighbors_threshold=max_neighbors,
+                enforce_max_strictly = self.enforce_max_neighbors_strictly,
             )
             if not torch.all(edge_mask):
                 subgraph["edge_index"] = subgraph["edge_index"][:, edge_mask]


### PR DESCRIPTION
This PR adds a new option to [`get_mask_neighbors_mask`](https://github.com/Open-Catalyst-Project/ocp/blob/a8ac36d75fc60d5b6d54b4019502941eb868fed0/ocpmodels/common/utils.py#L721) that enables more consistent handling of edges with the same length. Previously, this function would strictly enforce the maximum number of edges. This required a "tie-breaking" procedure in highly ordered bulks with many degenerate edges. It turns out that the tie-breaking was 1. biased based on unit cell construction and 2. inconsistent for identical structures with different unit cells. This problem is evident in Issue #428.

The default behavior is to continue enforcing the max strictly. However, this constraint can now be disabled with the option `enforce_max_strictly = False`. With this setting, tie-breaking is disabled. All edges which are equal in length (or within a specified tolerance) to the threshold edge will be included. In highly ordered systems, this can lead to a somewhat larger number of edges. The result is more consistent behavior with respect to unit cell choice. Here is a remake of the image in #428 with the same checkpoint, but using this new option:

![unit-cell-invariance](https://user-images.githubusercontent.com/93541000/229569855-b95a0579-9081-436d-92ef-2cc7bd9eb668.png)

With this option, predictions are now invariant to the choice of unit cell. This also fixes the oscillations seen with small unit cells. However, there are considerable differences in predictions compared to existing behavior (this also leads to worse metrics on existing checkpoints). For this reason the default behavior remains unchanged, but we suspect it would not take much fine-tuning to make checkpoints that use this option.

Right now, this option is only explicitly available in GemNet-OC. However, it can be applied to any model that uses `get_mask_neighbors_mask` by setting `self.enforce_max_neighbors_strictly = False`. I recommend that future models use this option by default, especially if they are to be used with bulks.