### PR TITLE
LMDB folder fix

### DIFF
--- a/ocpmodels/datasets/lmdb_dataset.py
+++ b/ocpmodels/datasets/lmdb_dataset.py
@@ -57,11 +57,16 @@ class LmdbDataset(Dataset):
 
             self._keys, self.envs = [], []
             for db_path in db_paths:
-                self.envs.append(self.connect_db(db_path))
-                length = pickle.loads(
-                    self.envs[-1].begin().get("length".encode("ascii"))
+                cur_env = self.connect_db(db_path)
+                self.envs.append(cur_env)
+
+                self._keys.append(
+                    [
+                        f"{j}".encode("ascii")
+                        for j in range(cur_env.stat()["entries"])
+                        if j != "length"
+                    ]
                 )
-                self._keys.append(list(range(length)))
 
             keylens = [len(k) for k in self._keys]
             self._keylen_cumulative = np.cumsum(keylens).tolist()

--- a/ocpmodels/datasets/lmdb_dataset.py
+++ b/ocpmodels/datasets/lmdb_dataset.py
@@ -34,6 +34,12 @@ class LmdbDataset(Dataset):
     Useful for Structure to Energy & Force (S2EF), Initial State to
     Relaxed State (IS2RS), and Initial State to Relaxed Energy (IS2RE) tasks.
 
+    The keys in the LMDB can be any ascii-decodable object; for historical
+    reasons they are often integers from 0 to len(lmdb_file) but that doesn't
+    have to be the case. Also for historical reasons any key names "length"
+    is ignored since that was used to infer length of many lmdbs in the same
+    folder, but lmdb lengths are now calculated directly from the number of keys.
+
     Args:
             config (dict): Dataset configuration
             transform (callable, optional): Data transform function.
@@ -141,7 +147,7 @@ class LmdbDataset(Dataset):
             subdir=False,
             readonly=True,
             lock=False,
-            readahead=False,
+            readahead=True,
             meminit=False,
             max_readers=1,
         )

--- a/ocpmodels/datasets/lmdb_dataset.py
+++ b/ocpmodels/datasets/lmdb_dataset.py
@@ -60,13 +60,18 @@ class LmdbDataset(Dataset):
                 cur_env = self.connect_db(db_path)
                 self.envs.append(cur_env)
 
-                self._keys.append(
-                    [
-                        f"{j}".encode("ascii")
-                        for j in range(cur_env.stat()["entries"])
-                        if j != "length"
-                    ]
-                )
+                # Load and encode all keys in the LMDB
+                cur_keys = [
+                    f"{j}".encode("ascii")
+                    for j in range(cur_env.stat()["entries"])
+                ]
+
+                # Discard any key called "length" which was included for
+                # legacy reasons in older OCP models
+                cur_keys = [key for key in cur_keys if key != "length"]
+
+                # Append the keys as a list
+                self._keys.append(cur_keys)
 
             keylens = [len(k) for k in self._keys]
             self._keylen_cumulative = np.cumsum(keylens).tolist()

--- a/ocpmodels/datasets/oc22_lmdb_dataset.py
+++ b/ocpmodels/datasets/oc22_lmdb_dataset.py
@@ -32,6 +32,12 @@ class OC22LmdbDataset(Dataset):
     Useful for Structure to Energy & Force (S2EF), Initial State to
     Relaxed State (IS2RS), and Initial State to Relaxed Energy (IS2RE) tasks.
 
+    The keys in the LMDB can be any ascii-decodable object; for historical
+    reasons they are often integers from 0 to len(lmdb_file) but that doesn't
+    have to be the case. Also for historical reasons any key names "length"
+    is ignored since that was used to infer length of many lmdbs in the same
+    folder, but lmdb lengths are now calculated directly from the number of keys.
+
     Args:
             config (dict): Dataset configuration
             transform (callable, optional): Data transform function.
@@ -52,14 +58,21 @@ class OC22LmdbDataset(Dataset):
 
             self._keys, self.envs = [], []
             for db_path in db_paths:
-                self.envs.append(self.connect_db(db_path))
-                try:
-                    length = pickle.loads(
-                        self.envs[-1].begin().get("length".encode("ascii"))
-                    )
-                except TypeError:
-                    length = self.envs[-1].stat()["entries"]
-                self._keys.append(list(range(length)))
+                cur_env = self.connect_db(db_path)
+                self.envs.append(cur_env)
+
+                # Load and encode all keys in the LMDB
+                cur_keys = [
+                    f"{j}".encode("ascii")
+                    for j in range(cur_env.stat()["entries"])
+                ]
+
+                # Discard any key called "length" which was included for
+                # legacy reasons in older OCP models
+                cur_keys = [key for key in cur_keys if key != "length"]
+
+                # Append the keys as a list
+                self._keys.append(cur_keys)
 
             keylens = [len(k) for k in self._keys]
             self._keylen_cumulative = np.cumsum(keylens).tolist()
@@ -200,7 +213,7 @@ class OC22LmdbDataset(Dataset):
             subdir=False,
             readonly=True,
             lock=False,
-            readahead=False,
+            readahead=True,
             meminit=False,
             max_readers=1,
         )


### PR DESCRIPTION
Generalize the code for loading folders of LMDB folders so that it works for
* Any keys are fine for the LMDB (not just 0->len(lmdb)), just like for LMDB file logic
* Ignore the "length" key which was included in older LMDB files and rely instead on the number of keys that are not "length"

Together, these changes also mean that any file that works as an LMDB in a folder of LMDBs will also work as a specific LMDB for training!