### PR TITLE
LMDB folder fix (#476)

### DIFF
--- a/ocpmodels/datasets/oc22_lmdb_dataset.py
+++ b/ocpmodels/datasets/oc22_lmdb_dataset.py
@@ -32,6 +32,12 @@ class OC22LmdbDataset(Dataset):
     Useful for Structure to Energy & Force (S2EF), Initial State to
     Relaxed State (IS2RS), and Initial State to Relaxed Energy (IS2RE) tasks.
 
+    The keys in the LMDB can be any ascii-decodable object; for historical
+    reasons they are often integers from 0 to len(lmdb_file) but that doesn't
+    have to be the case. Also for historical reasons any key names "length"
+    is ignored since that was used to infer length of many lmdbs in the same
+    folder, but lmdb lengths are now calculated directly from the number of keys.
+
     Args:
             config (dict): Dataset configuration
             transform (callable, optional): Data transform function.
@@ -52,14 +58,21 @@ class OC22LmdbDataset(Dataset):
 
             self._keys, self.envs = [], []
             for db_path in db_paths:
-                self.envs.append(self.connect_db(db_path))
-                try:
-                    length = pickle.loads(
-                        self.envs[-1].begin().get("length".encode("ascii"))
-                    )
-                except TypeError:
-                    length = self.envs[-1].stat()["entries"]
-                self._keys.append(list(range(length)))
+                cur_env = self.connect_db(db_path)
+                self.envs.append(cur_env)
+
+                # Load and encode all keys in the LMDB
+                cur_keys = [
+                    f"{j}".encode("ascii")
+                    for j in range(cur_env.stat()["entries"])
+                ]
+
+                # Discard any key called "length" which was included for
+                # legacy reasons in older OCP models
+                cur_keys = [key for key in cur_keys if key != "length"]
+
+                # Append the keys as a list
+                self._keys.append(cur_keys)
 
             keylens = [len(k) for k in self._keys]
             self._keylen_cumulative = np.cumsum(keylens).tolist()
@@ -200,7 +213,7 @@ class OC22LmdbDataset(Dataset):
             subdir=False,
             readonly=True,
             lock=False,
-            readahead=False,
+            readahead=True,
             meminit=False,
             max_readers=1,
         )


### PR DESCRIPTION
* first stab at lmdb len fix

* slight refactor so that the encode works correctly

* add readahead as default for lmdb, add some more docs to the lmdb dataset class

* same changes for oc22 dataset objects as for the default LmdbDataset