### PR TITLE
Lmdb length

### DIFF
--- a/ocpmodels/datasets/lmdb_dataset.py
+++ b/ocpmodels/datasets/lmdb_dataset.py
@@ -57,11 +57,16 @@ class LmdbDataset(Dataset):
 
             self._keys, self.envs = [], []
             for db_path in db_paths:
-                self.envs.append(self.connect_db(db_path))
-                length = pickle.loads(
-                    self.envs[-1].begin().get("length".encode("ascii"))
+                cur_env = self.connect_db(db_path)
+                self.envs.append(cur_env)
+
+                self._keys.append(
+                    [
+                        f"{j}".encode("ascii")
+                        for j in range(cur_env.stat()["entries"])
+                        if j != "length"
+                    ]
                 )
-                self._keys.append(list(range(length)))
 
             keylens = [len(k) for k in self._keys]
             self._keylen_cumulative = np.cumsum(keylens).tolist()

--- a/ocpmodels/datasets/lmdb_dataset.py
+++ b/ocpmodels/datasets/lmdb_dataset.py
@@ -34,6 +34,12 @@ class LmdbDataset(Dataset):
     Useful for Structure to Energy & Force (S2EF), Initial State to
     Relaxed State (IS2RS), and Initial State to Relaxed Energy (IS2RE) tasks.
 
+    The keys in the LMDB can be any ascii-decodable object; for historical
+    reasons they are often integers from 0 to len(lmdb_file) but that doesn't
+    have to be the case. Also for historical reasons any key names "length"
+    is ignored since that was used to infer length of many lmdbs in the same
+    folder, but lmdb lengths are now calculated directly from the number of keys.
+
     Args:
             config (dict): Dataset configuration
             transform (callable, optional): Data transform function.
@@ -141,7 +147,7 @@ class LmdbDataset(Dataset):
             subdir=False,
             readonly=True,
             lock=False,
-            readahead=False,
+            readahead=True,
             meminit=False,
             max_readers=1,
         )

--- a/ocpmodels/datasets/lmdb_dataset.py
+++ b/ocpmodels/datasets/lmdb_dataset.py
@@ -74,11 +74,8 @@ class LmdbDataset(Dataset):
                 if cur_env.begin().get("length".encode("ascii")) is not None:
                     num_entries -= 1
 
-                # Get all of the valid keys [0, len(lmdb)] encoded as ascii
-                cur_keys = [f"{j}".encode("ascii") for j in range(num_entries)]
-
-                # Append the keys as a list
-                self._keys.append(cur_keys)
+                # Append the keys (0->num_entries) as a list
+                self._keys.append(list(range(num_entries)))
 
             keylens = [len(k) for k in self._keys]
             self._keylen_cumulative = np.cumsum(keylens).tolist()
@@ -86,11 +83,16 @@ class LmdbDataset(Dataset):
         else:
             self.metadata_path = self.path.parent / "metadata.npz"
             self.env = self.connect_db(self.path)
-            self._keys = [
-                f"{j}".encode("ascii")
-                for j in range(self.env.stat()["entries"])
-            ]
-            self.num_samples = len(self._keys)
+
+            num_entries = self.env.stat()["entries"]
+
+            # If "length" encoded as ascii is present, we have one fewer
+            # data than the stats suggest
+            if self.env.begin().get("length".encode("ascii")) is not None:
+                num_entries -= 1
+
+            self._keys = list(range(num_entries))
+            self.num_samples = num_entries
 
         # If specified, limit dataset to only a portion of the entire dataset
         # total_shards: defines total chunks to partition dataset
@@ -127,12 +129,16 @@ class LmdbDataset(Dataset):
 
             # Return features.
             datapoint_pickled = (
-                self.envs[db_idx].begin().get(self._keys[db_idx][el_idx])
+                self.envs[db_idx]
+                .begin()
+                .get(f"{self._keys[db_idx][el_idx]}".encode("ascii"))
             )
             data_object = pyg2_data_transform(pickle.loads(datapoint_pickled))
             data_object.id = f"{db_idx}_{el_idx}"
         else:
-            datapoint_pickled = self.env.begin().get(self._keys[idx])
+            datapoint_pickled = self.env.begin().get(
+                f"{self._keys[idx]}".encode("ascii")
+            )
             data_object = pyg2_data_transform(pickle.loads(datapoint_pickled))
 
         if self.transform is not None:

--- a/ocpmodels/datasets/lmdb_dataset.py
+++ b/ocpmodels/datasets/lmdb_dataset.py
@@ -34,10 +34,9 @@ class LmdbDataset(Dataset):
     Useful for Structure to Energy & Force (S2EF), Initial State to
     Relaxed State (IS2RS), and Initial State to Relaxed Energy (IS2RE) tasks.
 
-    The keys in the LMDB can be any ascii-decodable object; for historical
-    reasons they are often integers from 0 to len(lmdb_file) but that doesn't
-    have to be the case. Also for historical reasons any key names "length"
-    is ignored since that was used to infer length of many lmdbs in the same
+    The keys in the LMDB must be integers (stored as ascii objects) starting
+    from 0 through the length of the LMDB. For historical reasons any key names
+    "length" is ignored since that was used to infer length of many lmdbs in the same
     folder, but lmdb lengths are now calculated directly from the number of keys.
 
     Args:
@@ -66,15 +65,17 @@ class LmdbDataset(Dataset):
                 cur_env = self.connect_db(db_path)
                 self.envs.append(cur_env)
 
-                # Load and encode all keys in the LMDB
-                cur_keys = [
-                    f"{j}".encode("ascii")
-                    for j in range(cur_env.stat()["entries"])
-                ]
+                # Get the number of stores data from the number of entries
+                # in the LMDB
+                num_entries = cur_env.stat()["entries"]
 
-                # Discard any key called "length" which was included for
-                # legacy reasons in older OCP models
-                cur_keys = [key for key in cur_keys if key != "length"]
+                # If "length" encoded as ascii is present, we have one fewer
+                # data than the stats suggest
+                if cur_env.begin().get("length".encode("ascii")) is not None:
+                    num_entries -= 1
+
+                # Get all of the valid keys [0, len(lmdb)] encoded as ascii
+                cur_keys = [f"{j}".encode("ascii") for j in range(num_entries)]
 
                 # Append the keys as a list
                 self._keys.append(cur_keys)
@@ -126,9 +127,7 @@ class LmdbDataset(Dataset):
 
             # Return features.
             datapoint_pickled = (
-                self.envs[db_idx]
-                .begin()
-                .get(f"{self._keys[db_idx][el_idx]}".encode("ascii"))
+                self.envs[db_idx].begin().get(self._keys[db_idx][el_idx])
             )
             data_object = pyg2_data_transform(pickle.loads(datapoint_pickled))
             data_object.id = f"{db_idx}_{el_idx}"

--- a/ocpmodels/datasets/lmdb_dataset.py
+++ b/ocpmodels/datasets/lmdb_dataset.py
@@ -60,13 +60,18 @@ class LmdbDataset(Dataset):
                 cur_env = self.connect_db(db_path)
                 self.envs.append(cur_env)
 
-                self._keys.append(
-                    [
-                        f"{j}".encode("ascii")
-                        for j in range(cur_env.stat()["entries"])
-                        if j != "length"
-                    ]
-                )
+                # Load and encode all keys in the LMDB
+                cur_keys = [
+                    f"{j}".encode("ascii")
+                    for j in range(cur_env.stat()["entries"])
+                ]
+
+                # Discard any key called "length" which was included for
+                # legacy reasons in older OCP models
+                cur_keys = [key for key in cur_keys if key != "length"]
+
+                # Append the keys as a list
+                self._keys.append(cur_keys)
 
             keylens = [len(k) for k in self._keys]
             self._keylen_cumulative = np.cumsum(keylens).tolist()

--- a/ocpmodels/datasets/lmdb_dataset.py
+++ b/ocpmodels/datasets/lmdb_dataset.py
@@ -85,13 +85,13 @@ class LmdbDataset(Dataset):
             self.env = self.connect_db(self.path)
 
             # If "length" encoded as ascii is present, use that
-            length_entry = cur_env.begin().get("length".encode("ascii"))
+            length_entry = self.env.begin().get("length".encode("ascii"))
             if length_entry is not None:
                 num_entries = pickle.loads(length_entry)
             else:
                 # Get the number of stores data from the number of entries
                 # in the LMDB
-                num_entries = cur_env.stat()["entries"]
+                num_entries = self.env.stat()["entries"]
 
             self._keys = list(range(num_entries))
             self.num_samples = num_entries

--- a/ocpmodels/datasets/oc22_lmdb_dataset.py
+++ b/ocpmodels/datasets/oc22_lmdb_dataset.py
@@ -69,11 +69,8 @@ class OC22LmdbDataset(Dataset):
                 if cur_env.begin().get("length".encode("ascii")) is not None:
                     num_entries -= 1
 
-                # Get all of the valid keys [0, len(lmdb)] encoded as ascii
-                cur_keys = [f"{j}".encode("ascii") for j in range(num_entries)]
-
-                # Append the keys as a list
-                self._keys.append(cur_keys)
+                # Append the keys (0->num_entries) as a list
+                self._keys.append(list(range(num_entries)))
 
             keylens = [len(k) for k in self._keys]
             self._keylen_cumulative = np.cumsum(keylens).tolist()
@@ -97,11 +94,16 @@ class OC22LmdbDataset(Dataset):
         else:
             self.metadata_path = self.path.parent / "metadata.npz"
             self.env = self.connect_db(self.path)
-            self._keys = [
-                f"{j}".encode("ascii")
-                for j in range(self.env.stat()["entries"])
-            ]
-            self.num_samples = len(self._keys)
+
+            num_entries = self.env.stat()["entries"]
+
+            # If "length" encoded as ascii is present, we have one fewer
+            # data than the stats suggest
+            if self.env.begin().get("length".encode("ascii")) is not None:
+                num_entries -= 1
+
+            self._keys = list(range(num_entries))
+            self.num_samples = num_entries
 
         self.transform = transform
         self.lin_ref = self.oc20_ref = False
@@ -137,12 +139,16 @@ class OC22LmdbDataset(Dataset):
 
             # Return features.
             datapoint_pickled = (
-                self.envs[db_idx].begin().get(self._keys[db_idx][el_idx])
+                self.envs[db_idx]
+                .begin()
+                .get(f"{self._keys[db_idx][el_idx]}".encode("ascii"))
             )
             data_object = pyg2_data_transform(pickle.loads(datapoint_pickled))
             data_object.id = f"{db_idx}_{el_idx}"
         else:
-            datapoint_pickled = self.env.begin().get(self._keys[idx])
+            datapoint_pickled = self.env.begin().get(
+                f"{self._keys[idx]}".encode("ascii")
+            )
             data_object = pyg2_data_transform(pickle.loads(datapoint_pickled))
 
         if self.transform is not None:

--- a/ocpmodels/datasets/oc22_lmdb_dataset.py
+++ b/ocpmodels/datasets/oc22_lmdb_dataset.py
@@ -61,15 +61,17 @@ class OC22LmdbDataset(Dataset):
                 cur_env = self.connect_db(db_path)
                 self.envs.append(cur_env)
 
-                # Load and encode all keys in the LMDB
-                cur_keys = [
-                    f"{j}".encode("ascii")
-                    for j in range(cur_env.stat()["entries"])
-                ]
+                # Get the number of stores data from the number of entries
+                # in the LMDB
+                num_entries = cur_env.stat()["entries"]
 
-                # Discard any key called "length" which was included for
-                # legacy reasons in older OCP models
-                cur_keys = [key for key in cur_keys if key != "length"]
+                # If "length" encoded as ascii is present, we have one fewer
+                # data than the stats suggest
+                if cur_env.begin().get("length".encode("ascii")) is not None:
+                    num_entries -= 1
+
+                # Get all of the valid keys [0, len(lmdb)] encoded as ascii
+                cur_keys = [f"{j}".encode("ascii") for j in range(num_entries)]
 
                 # Append the keys as a list
                 self._keys.append(cur_keys)
@@ -136,9 +138,7 @@ class OC22LmdbDataset(Dataset):
 
             # Return features.
             datapoint_pickled = (
-                self.envs[db_idx]
-                .begin()
-                .get(f"{self._keys[db_idx][el_idx]}".encode("ascii"))
+                self.envs[db_idx].begin().get(self._keys[db_idx][el_idx])
             )
             data_object = pyg2_data_transform(pickle.loads(datapoint_pickled))
             data_object.id = f"{db_idx}_{el_idx}"

--- a/ocpmodels/datasets/oc22_lmdb_dataset.py
+++ b/ocpmodels/datasets/oc22_lmdb_dataset.py
@@ -32,10 +32,9 @@ class OC22LmdbDataset(Dataset):
     Useful for Structure to Energy & Force (S2EF), Initial State to
     Relaxed State (IS2RS), and Initial State to Relaxed Energy (IS2RE) tasks.
 
-    The keys in the LMDB can be any ascii-decodable object; for historical
-    reasons they are often integers from 0 to len(lmdb_file) but that doesn't
-    have to be the case. Also for historical reasons any key names "length"
-    is ignored since that was used to infer length of many lmdbs in the same
+    The keys in the LMDB must be integers (stored as ascii objects) starting
+    from 0 through the length of the LMDB. For historical reasons any key names
+    "length" is ignored since that was used to infer length of many lmdbs in the same
     folder, but lmdb lengths are now calculated directly from the number of keys.
 
     Args:

--- a/ocpmodels/datasets/oc22_lmdb_dataset.py
+++ b/ocpmodels/datasets/oc22_lmdb_dataset.py
@@ -32,6 +32,12 @@ class OC22LmdbDataset(Dataset):
     Useful for Structure to Energy & Force (S2EF), Initial State to
     Relaxed State (IS2RS), and Initial State to Relaxed Energy (IS2RE) tasks.
 
+    The keys in the LMDB can be any ascii-decodable object; for historical
+    reasons they are often integers from 0 to len(lmdb_file) but that doesn't
+    have to be the case. Also for historical reasons any key names "length"
+    is ignored since that was used to infer length of many lmdbs in the same
+    folder, but lmdb lengths are now calculated directly from the number of keys.
+
     Args:
             config (dict): Dataset configuration
             transform (callable, optional): Data transform function.
@@ -52,14 +58,21 @@ class OC22LmdbDataset(Dataset):
 
             self._keys, self.envs = [], []
             for db_path in db_paths:
-                self.envs.append(self.connect_db(db_path))
-                try:
-                    length = pickle.loads(
-                        self.envs[-1].begin().get("length".encode("ascii"))
-                    )
-                except TypeError:
-                    length = self.envs[-1].stat()["entries"]
-                self._keys.append(list(range(length)))
+                cur_env = self.connect_db(db_path)
+                self.envs.append(cur_env)
+
+                # Load and encode all keys in the LMDB
+                cur_keys = [
+                    f"{j}".encode("ascii")
+                    for j in range(cur_env.stat()["entries"])
+                ]
+
+                # Discard any key called "length" which was included for
+                # legacy reasons in older OCP models
+                cur_keys = [key for key in cur_keys if key != "length"]
+
+                # Append the keys as a list
+                self._keys.append(cur_keys)
 
             keylens = [len(k) for k in self._keys]
             self._keylen_cumulative = np.cumsum(keylens).tolist()
@@ -200,7 +213,7 @@ class OC22LmdbDataset(Dataset):
             subdir=False,
             readonly=True,
             lock=False,
-            readahead=False,
+            readahead=True,
             meminit=False,
             max_readers=1,
         )


### PR DESCRIPTION
- second stab at lmdb len fix
- slight refactor so that the encode works correctly
- add readahead as default for lmdb, add some more docs to the lmdb dataset class
- same changes for oc22 dataset objects as for the default LmdbDataset