### PR TITLE
Skipping scheduler setup in EquiformerV2 trainer if train_loader isn't defined

### DIFF
--- a/ocpmodels/models/equiformer_v2/trainers/forces_trainer.py
+++ b/ocpmodels/models/equiformer_v2/trainers/forces_trainer.py
@@ -138,16 +138,20 @@ class EquiformerV2ForcesTrainer(ForcesTrainer):
         ]
 
         # convert epochs into number of steps
-        n_iter_per_epoch = len(self.train_loader)
-        scheduler_params = self.config["optim"]["scheduler_params"]
-        for k in scheduler_params.keys():
-            if "epochs" in k:
-                if isinstance(scheduler_params[k], (int, float, list)):
-                    scheduler_params[k] = multiply(
-                        scheduler_params[k], n_iter_per_epoch
-                    )
+        if self.train_loader is None:
+            logging.warning("Skipping scheduler setup. No training set found.")
+            self.scheduler = None
+        else:
+            n_iter_per_epoch = len(self.train_loader)
+            scheduler_params = self.config["optim"]["scheduler_params"]
+            for k in scheduler_params.keys():
+                if "epochs" in k:
+                    if isinstance(scheduler_params[k], (int, float, list)):
+                        scheduler_params[k] = multiply(
+                            scheduler_params[k], n_iter_per_epoch
+                        )
+            self.scheduler = LRScheduler(self.optimizer, self.config["optim"])
 
-        self.scheduler = LRScheduler(self.optimizer, self.config["optim"])
         self.clip_grad_norm = self.config["optim"].get("clip_grad_norm")
         self.ema_decay = self.config["optim"].get("ema_decay")
         if self.ema_decay:


### PR DESCRIPTION
The scheduler setup for EquiformerV2 uses the training dataloader to convert epochs to steps, which doesn't work when initializing the model with `OCPCalculator` since there's typically no training dataset. This PR avoids setting up the scheduler for EquiformerV2 when there isn't a training set and the following should work now (refs #540):

```python3

from ocpmodels.common.relaxation.ase_utils import OCPCalculator
calc = OCPCalculator(checkpoint='eq2_83M_2M.pt', cpu=False)
```