### PR TITLE
[cli] Add cli skeleton

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,107 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+import functools
+import logging
+from typing import Callable, TypeVar
+
+import click
+from click_option_group import optgroup
+
+T = TypeVar("T")
+
+
+def _logging_options(func: Callable[..., T]) -> Callable[..., T]:
+    """
+    Common CLI options related to logging.
+    """
+
+    @optgroup.group("Logging")
+    @optgroup.option(
+        "--log-level",
+        type=click.Choice(["ERROR", "WARNING", "WARN", "INFO", "DEBUG"]),
+        default="INFO",
+        envvar="LOG_LEVEL",
+        help="The minimum level of log statements to print.",
+    )
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs) -> T:
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@click.group(
+    context_settings={"max_content_width": 120, "show_default": True},
+    help="Graph networks for electrocatalyst design",
+)
+def cli() -> None:
+    pass
+
+
+@cli.command(
+    name="download",
+    short_help="",
+    help=(),
+)
+@_logging_options
+def download(log_level: str):
+    logging.basicConfig(level=log_level)
+
+
+@cli.command(
+    name="train",
+    short_help="",
+    help=(),
+)
+@_logging_options
+def train(log_level: str):
+    logging.basicConfig(level=log_level)
+
+
+@cli.command(
+    name="finetune",
+    short_help="",
+    help=(),
+)
+@_logging_options
+def finetune(log_level: str):
+    logging.basicConfig(level=log_level)
+
+
+@cli.command(
+    name="validate",
+    short_help="",
+    help=(),
+)
+@_logging_options
+def validate(log_level: str):
+    logging.basicConfig(level=log_level)
+
+
+@cli.command(
+    name="predict",
+    short_help="",
+    help=(),
+)
+@_logging_options
+def predict(log_level: str):
+    logging.basicConfig(level=log_level)
+
+
+@cli.command(
+    name="relax",
+    short_help="",
+    help=(),
+)
+@_logging_options
+def relax(log_level: str):
+    logging.basicConfig(level=log_level)
+
+
+if __name__ == "__main__":
+    cli()

--- a/env.common.yml
+++ b/env.common.yml
@@ -6,6 +6,8 @@ channels:
 dependencies:
 - ase=3.22.1
 - black=22.3.0
+- click=8.0.4
+- click-option-group=0.5.6
 - e3nn=0.4.4
 - matplotlib
 - numba


### PR DESCRIPTION
Add click for cli generation with placeholders for supported methods. Examples:

```
$ python cli.py --help
Usage: cli.py [OPTIONS] COMMAND [ARGS]...

  Graph networks for electrocatalyst design

Options:
  --help  Show this message and exit.

Commands:
  download
  finetune
  predict
  relax
  train
  validate
```

```
$ python cli.py download --help
Usage: cli.py download [OPTIONS]

Options:
  Logging: 
    --log-level [ERROR|WARNING|WARN|INFO|DEBUG]
                                  The minimum level of log statements to print.  [default: INFO]
  --help                          Show this message and exit.
```

\* We'll add a setup file later that will let us replace `python cli.py` with `ocp`