### PR TITLE
Cli train impl

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -6,7 +6,6 @@ LICENSE file in the root directory of this source tree.
 """
 
 import functools
-import logging
 import os
 from typing import Any, Callable, TypeVar
 
@@ -14,6 +13,7 @@ import click
 from click_option_group import optgroup
 
 import ocpmodels
+from ocpmodels.common.utils import setup_logging
 from cli.download_data import DOWNLOAD_LINKS_s2ef, get_data
 
 T = TypeVar("T")
@@ -134,7 +134,7 @@ def download_s2ef(
     test_data: bool,
     log_level: str,
 ):
-    logging.basicConfig(level=log_level)
+    setup_logging(level=log_level)
     get_data(
         datadir=data_path,
         task="s2ef",
@@ -159,7 +159,7 @@ def download_is2re(
     keep: bool,
     log_level: str,
 ):
-    logging.basicConfig(level=log_level)
+    setup_logging(level=log_level)
     get_data(
         datadir=data_path,
         task="is2re",
@@ -175,7 +175,7 @@ def download_is2re(
 )
 @_logging_options
 def train(log_level: str):
-    logging.basicConfig(level=log_level)
+    setup_logging(level=log_level)
 
 
 @cli.command(
@@ -185,7 +185,7 @@ def train(log_level: str):
 )
 @_logging_options
 def finetune(log_level: str):
-    logging.basicConfig(level=log_level)
+    setup_logging(level=log_level)
 
 
 @cli.command(
@@ -195,7 +195,7 @@ def finetune(log_level: str):
 )
 @_logging_options
 def validate(log_level: str):
-    logging.basicConfig(level=log_level)
+    setup_logging(level=log_level)
 
 
 @cli.command(
@@ -205,7 +205,7 @@ def validate(log_level: str):
 )
 @_logging_options
 def predict(log_level: str):
-    logging.basicConfig(level=log_level)
+    setup_logging(level=log_level)
 
 
 @cli.command(
@@ -215,7 +215,7 @@ def predict(log_level: str):
 )
 @_logging_options
 def relax(log_level: str):
-    logging.basicConfig(level=log_level)
+    setup_logging(level=log_level)
 
 
 if __name__ == "__main__":

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -7,14 +7,16 @@ LICENSE file in the root directory of this source tree.
 
 import functools
 import os
-from typing import Any, Callable, TypeVar
+from pathlib import Path
+from typing import Any, Callable, Optional, Tuple, TypeVar
 
 import click
 from click_option_group import optgroup
 
 import ocpmodels
-from ocpmodels.common.utils import setup_logging
 from cli.download_data import DOWNLOAD_LINKS_s2ef, get_data
+from cli.runner import run_with_config
+from ocpmodels.common.utils import build_config, setup_logging
 
 T = TypeVar("T")
 
@@ -31,6 +33,32 @@ def _logging_options(func: Callable[..., T]) -> Callable[..., T]:
         default="INFO",
         envvar="LOG_LEVEL",
         help="The minimum level of log statements to print.",
+    )
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> T:
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def _runner_logging_options(func: Callable[..., T]) -> Callable[..., T]:
+    """
+    Extension of _logging_options that adds options common to all commands
+    that use a Runner instance.
+    """
+
+    @_logging_options
+    @optgroup.option(
+        "--logdir",
+        type=Path,
+        default="logs",
+        help="Name of the subdirectory where logs will be saved.",
+    )
+    @optgroup.option(
+        "--timestamp-id",
+        type=str,
+        default=None,
+        help="Overrides the ID used in timestamps.",
     )
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> T:
@@ -59,6 +87,194 @@ def _download_options(func: Callable[..., T]) -> Callable[..., T]:
             "Preserve intermediate directories and files after download "
             "and preprocessing steps have completed."
         ),
+    )
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> T:
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def _runner_job_options(func: Callable[..., T]) -> Callable[..., T]:
+    """
+    Common CLI options to for job settings in Runner instances.
+    """
+
+    @optgroup.group("Job")
+    @optgroup.option(
+        "--checkpoint-path",
+        type=str,
+        default=None,
+        help="Path to the model checkpoint to load.",
+    )
+    # TODO Add option to set checkpoint by name and download it
+    @optgroup.option(
+        "--config-yml",
+        type=Path,
+        required=True,
+        help=(
+            "Path to a config file that lists data, model, and optimization "
+            "parameters."
+        ),
+    )
+    @optgroup.option(
+        "--config",
+        type=str,
+        multiple=True,
+        default=[],
+        help=(
+            "Sets a single configuration option, taking precendence over "
+            "values defined in the file pointed to by --config-yml. Use "
+            "key=value with '.' characters to separate nested key names. "
+            "For example: --config parent.config=val. Can be used more than "
+            "once to set multiple key/value pairs."
+        ),
+    )
+    @optgroup.option(
+        "--sweep-yml",
+        type=Path,
+        default=None,
+        help="Path to the config file with parameter sweeps.",
+    )
+    @optgroup.option(
+        "--run-dir",
+        type=str,
+        default="./",
+        help="Directory in which checkpoints, logs, and results will be saved.",
+    )
+    @optgroup.option(
+        "--identifier",
+        type=str,
+        default="",
+        help=(
+            "Experimental identifier that will be appended to the name of the "
+            "directory in which checkpoints, logs, and results are saved."
+        ),
+    )
+    @optgroup.option(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed for torch, cuda, and numpy.",
+    )
+    @optgroup.option(
+        "--debug",
+        is_flag=True,
+        default=False,
+        help="Run in debug mode.",
+    )
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> T:
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def _runner_cluster_options(func: Callable[..., T]) -> Callable[..., T]:
+    """
+    Common CLI options for cluster settings in Runner instances.
+    """
+
+    @optgroup.group("Cluster")
+    @optgroup.option(
+        "--submit",
+        is_flag=True,
+        default=False,
+        help="Submit job to cluster.",
+    )
+    @optgroup.option(
+        "--slurm-partition",
+        type=str,
+        default="ocp",
+        help="Name of the slurm partition to submit to.",
+    )
+    @optgroup.option(
+        "--slurm-mem",
+        type=int,
+        default=80,
+        help="Memory limit, in GB, of jobs submitted with slurm.",
+    )
+    @optgroup.option(
+        "--slurm-timeout",
+        type=int,
+        default=72,
+        help="Time limit, in hours, of jobs submitted with slurm.",
+    )
+    @optgroup.option(
+        "--summit",
+        is_flag=True,
+        default=False,
+        help="Running on Summit cluster.",
+    )
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> T:
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def _runner_resource_options(func: Callable[..., T]) -> Callable[..., T]:
+    """
+    Common CLI options for resource settings in Runner instances.
+    """
+
+    @optgroup.group("Resources")
+    @optgroup.option(
+        "--num-nodes",
+        type=int,
+        default=1,
+        help="Number of nodes to request",
+    )
+    @optgroup.option(
+        "--num-gpus",
+        type=int,
+        default=1,
+        help="Number of GPUs to request.",
+    )
+    @optgroup.option(
+        "--cpu",
+        is_flag=True,
+        default=False,
+        help="Run with CPUs only.",
+    )
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> T:
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def _runner_parallelization_options(
+    func: Callable[..., T]
+) -> Callable[..., T]:
+    """
+    Common CLI options for parallelization settings in Runner instances.
+    """
+
+    @optgroup.group("Parallelization")
+    @optgroup.option(
+        "--distributed",
+        is_flag=True,
+        default=False,
+        help="Run with DDP (PyTorch Distributed Data Parallel).",
+    )
+    @optgroup.option(
+        "--distributed-backend",
+        type=str,
+        default="nccl",
+        help="Backend for DDP.",
+    )
+    @optgroup.option(
+        "--distributed-port",
+        type=int,
+        default=13356,
+        help="Port on master for DDP",
+    )
+    @optgroup.option(
+        "--no-ddp",
+        is_flag=True,
+        default=False,
+        help="Do not use DDP.",
     )
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> T:
@@ -170,12 +386,104 @@ def download_is2re(
 
 @cli.command(
     name="train",
-    short_help="",
-    help=(),
+    short_help="Train a new model",
+    help="Train a new model.",
 )
-@_logging_options
-def train(log_level: str):
+@_runner_job_options
+@optgroup.option(
+    "--amp",
+    is_flag=True,
+    default=False,
+    help="Use mixed-precision training.",
+)
+@_runner_cluster_options
+@_runner_resource_options
+@_runner_parallelization_options
+@optgroup.option(
+    "--gp-gpus",
+    type=int,
+    default=None,
+    help="Number of GPUs to split the graph over in Graph Parallel training.",
+)
+@optgroup.option(
+    "--local-rank",
+    type=int,
+    default=0,
+    help="Local rank in distributed training.",
+)
+@_runner_logging_options
+@optgroup.option(
+    "--print-every",
+    type=int,
+    default=10,
+    help="Number of iterations to run before each log statement is generated.",
+)
+def train(
+    checkpoint_path: Optional[str],
+    config_yml: Path,
+    config: Tuple[str, ...],
+    sweep_yml: Optional[Path],
+    run_dir: str,
+    identifier: str,
+    seed: int,
+    debug: bool,
+    amp: bool,
+    submit: bool,
+    slurm_partition: str,
+    slurm_mem: int,
+    slurm_timeout: int,
+    summit: bool,
+    num_nodes: int,
+    num_gpus: int,
+    cpu: bool,
+    distributed: bool,
+    distributed_backend: str,
+    distributed_port: int,
+    no_ddp: bool,
+    gp_gpus: int,
+    local_rank: int,
+    log_level: str,
+    logdir: str,
+    timestamp_id: Optional[str],
+    print_every: int,
+):
     setup_logging(level=log_level)
+    config = build_config(
+        mode="train",
+        config_yml=str(config_yml),
+        config_overrides=list(config),
+        identifier=identifier,
+        timestamp_id=timestamp_id,
+        seed=seed,
+        debug=debug,
+        run_dir=run_dir,
+        print_every=print_every,
+        amp=amp,
+        checkpoint=checkpoint_path,
+        cpu_only=cpu,
+        submit=submit,
+        summit=summit,
+        local_rank=local_rank,
+        distributed_port=distributed_port,
+        distributed_backend=distributed_backend,
+        num_nodes=num_nodes,
+        num_gpus=num_gpus,
+        no_ddp=no_ddp,
+        gp_gpus=gp_gpus,
+    )
+    run_with_config(
+        config=config,
+        sweep_yml=sweep_yml,
+        submit=submit,
+        logdir=logdir,
+        identifier=identifier,
+        slurm_mem=slurm_mem,
+        slurm_timeout=slurm_timeout,
+        slurm_partition=slurm_partition,
+        num_gpus=num_gpus,
+        num_nodes=num_nodes,
+        distributed=distributed,
+    )
 
 
 @cli.command(
@@ -193,7 +501,11 @@ def finetune(log_level: str):
     short_help="",
     help=(),
 )
-@_logging_options
+@_runner_job_options
+@_runner_cluster_options
+@_runner_resource_options
+@_runner_parallelization_options
+@_runner_logging_options
 def validate(log_level: str):
     setup_logging(level=log_level)
 
@@ -203,7 +515,11 @@ def validate(log_level: str):
     short_help="",
     help=(),
 )
-@_logging_options
+@_runner_job_options
+@_runner_cluster_options
+@_runner_resource_options
+@_runner_parallelization_options
+@_runner_logging_options
 def predict(log_level: str):
     setup_logging(level=log_level)
 
@@ -213,7 +529,11 @@ def predict(log_level: str):
     short_help="",
     help=(),
 )
-@_logging_options
+@_runner_job_options
+@_runner_cluster_options
+@_runner_resource_options
+@_runner_parallelization_options
+@_runner_logging_options
 def relax(log_level: str):
     setup_logging(level=log_level)
 

--- a/cli/runner.py
+++ b/cli/runner.py
@@ -5,20 +5,17 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-import argparse
 import copy
 import logging
-from typing import List
+from pathlib import Path
+from typing import Any, Dict, Optional
 
 import submitit
 
-from ocpmodels.common.flags import flags
 from ocpmodels.common.utils import (
-    build_config,
     create_grid,
     new_trainer_context,
     save_experiment_log,
-    setup_logging,
 )
 
 
@@ -26,8 +23,10 @@ class Runner(submitit.helpers.Checkpointable):
     def __init__(self) -> None:
         self.config = None
 
-    def __call__(self, config) -> None:
-        with new_trainer_context(args=args, config=config) as ctx:
+    def __call__(self, config, distributed) -> None:
+        with new_trainer_context(
+            config=config, distributed=distributed
+        ) as ctx:
             self.config = ctx.config
             self.task = ctx.task
             self.trainer = ctx.trainer
@@ -45,48 +44,55 @@ class Runner(submitit.helpers.Checkpointable):
         return submitit.helpers.DelayedSubmission(new_runner, self.config)
 
 
-if __name__ == "__main__":
-    setup_logging()
-
-    parser: argparse.ArgumentParser = flags.get_parser()
-    args: argparse.Namespace
-    override_args: List[str]
-    args, override_args = parser.parse_known_args()
-    config = build_config(args, override_args)
-
-    if args.submit:  # Run on cluster
+def run_with_config(
+    config: Dict[str, Any],
+    sweep_yml: Optional[Path],
+    submit: bool,
+    logdir: str,
+    identifier: str,
+    slurm_mem: int,
+    slurm_timeout: int,
+    slurm_partition: str,
+    num_gpus: int,
+    num_nodes: int,
+    distributed: bool,
+) -> None:
+    if submit:  # Run on cluster
         slurm_add_params = config.get(
             "slurm", None
         )  # additional slurm arguments
-        if args.sweep_yml:  # Run grid search
-            configs = create_grid(config, args.sweep_yml)
+        if sweep_yml:  # Run grid search
+            configs = create_grid(config, str(sweep_yml))
         else:
             configs = [config]
 
         logging.info(f"Submitting {len(configs)} jobs")
         executor = submitit.AutoExecutor(
-            folder=args.logdir / "%j", slurm_max_num_timeout=3
+            folder=logdir / "%j",
+            slurm_max_num_timeout=3,
         )
         executor.update_parameters(
-            name=args.identifier,
-            mem_gb=args.slurm_mem,
-            timeout_min=args.slurm_timeout * 60,
-            slurm_partition=args.slurm_partition,
-            gpus_per_node=args.num_gpus,
+            name=identifier,
+            mem_gb=slurm_mem,
+            timeout_min=slurm_timeout * 60,
+            slurm_partition=slurm_partition,
+            gpus_per_node=num_gpus,
             cpus_per_task=(config["optim"]["num_workers"] + 1),
-            tasks_per_node=(args.num_gpus if args.distributed else 1),
-            nodes=args.num_nodes,
+            tasks_per_node=(num_gpus if distributed else 1),
+            nodes=num_nodes,
             slurm_additional_parameters=slurm_add_params,
         )
         for config in configs:
             config["slurm"] = copy.deepcopy(executor.parameters)
             config["slurm"]["folder"] = str(executor.folder)
-        jobs = executor.map_array(Runner(), configs)
+        jobs = executor.map_array(
+            Runner(), configs, [distributed] * len(configs)
+        )
         logging.info(
             f"Submitted jobs: {', '.join([job.job_id for job in jobs])}"
         )
-        log_file = save_experiment_log(args, jobs, configs)
+        log_file = save_experiment_log(logdir, jobs, configs)
         logging.info(f"Experiment log saved to: {log_file}")
 
     else:  # Run locally
-        Runner()(config)
+        Runner()(config, distributed)

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from functools import wraps
 from itertools import product
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Text, Tuple, Union
 
 import numpy as np
 import torch
@@ -917,12 +917,12 @@ class SeverityLevelBetween(logging.Filter):
         return self.min_level <= record.levelno < self.max_level
 
 
-def setup_logging() -> None:
+def setup_logging(level: Union[int, Text] = logging.INFO) -> None:
     root = logging.getLogger()
 
     # Perform setup only if logging has not been configured
     if not root.hasHandlers():
-        root.setLevel(logging.INFO)
+        root.setLevel(level)
 
         log_formatter = logging.Formatter(
             "%(asctime)s (%(levelname)s): %(message)s",

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -15,14 +15,23 @@ import logging
 import os
 import sys
 import time
-from argparse import Namespace
 from bisect import bisect
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import wraps
 from itertools import product
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Text, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Text,
+    Tuple,
+    Union,
+)
 
 import numpy as np
 import torch
@@ -411,8 +420,30 @@ def load_config(path: str, previous_includes: list = []):
     return config, duplicates_warning, duplicates_error
 
 
-def build_config(args, args_override):
-    config, duplicates_warning, duplicates_error = load_config(args.config_yml)
+def build_config(
+    mode: str,
+    config_yml: str,
+    config_overrides: List[str],
+    identifier: str,
+    timestamp_id: Optional[str],
+    seed: int,
+    debug: bool,
+    run_dir: str,
+    print_every: int,
+    amp: bool,
+    checkpoint: Optional[str],
+    cpu_only: bool,
+    submit: bool,
+    summit: bool,
+    local_rank: int,
+    distributed_port: int,
+    distributed_backend: str,
+    num_nodes: int,
+    num_gpus: int,
+    no_ddp: bool,
+    gp_gpus: int,
+):
+    config, duplicates_warning, duplicates_error = load_config(config_yml)
     if len(duplicates_warning) > 0:
         logging.warning(
             f"Overwritten config parameters from included configs "
@@ -425,31 +456,31 @@ def build_config(args, args_override):
         )
 
     # Check for overridden parameters.
-    if args_override != []:
-        overrides = create_dict_from_args(args_override)
+    if config_overrides != []:
+        overrides = create_dict_from_args(config_overrides)
         config, _ = merge_dicts(config, overrides)
 
     # Some other flags.
-    config["mode"] = args.mode
-    config["identifier"] = args.identifier
-    config["timestamp_id"] = args.timestamp_id
-    config["seed"] = args.seed
-    config["is_debug"] = args.debug
-    config["run_dir"] = args.run_dir
-    config["print_every"] = args.print_every
-    config["amp"] = args.amp
-    config["checkpoint"] = args.checkpoint
-    config["cpu"] = args.cpu
+    config["mode"] = mode
+    config["identifier"] = identifier
+    config["timestamp_id"] = timestamp_id
+    config["seed"] = seed
+    config["is_debug"] = debug
+    config["run_dir"] = run_dir
+    config["print_every"] = print_every
+    config["amp"] = amp
+    config["checkpoint"] = checkpoint
+    config["cpu"] = cpu_only
     # Submit
-    config["submit"] = args.submit
-    config["summit"] = args.summit
+    config["submit"] = submit
+    config["summit"] = summit
     # Distributed
-    config["local_rank"] = args.local_rank
-    config["distributed_port"] = args.distributed_port
-    config["world_size"] = args.num_nodes * args.num_gpus
-    config["distributed_backend"] = args.distributed_backend
-    config["noddp"] = args.no_ddp
-    config["gp_gpus"] = args.gp_gpus
+    config["local_rank"] = local_rank
+    config["distributed_port"] = distributed_port
+    config["world_size"] = num_nodes * num_gpus
+    config["distributed_backend"] = distributed_backend
+    config["noddp"] = no_ddp
+    config["gp_gpus"] = gp_gpus
 
     return config
 
@@ -488,8 +519,8 @@ def create_grid(base_config, sweep_file: str):
     return configs
 
 
-def save_experiment_log(args, jobs, configs):
-    log_file = args.logdir / "exp" / time.strftime("%Y-%m-%d-%I-%M-%S%p.log")
+def save_experiment_log(logdir, jobs, configs):
+    log_file = logdir / "exp" / time.strftime("%Y-%m-%d-%I-%M-%S%p.log")
     log_file.parent.mkdir(exist_ok=True, parents=True)
     with open(log_file, "w") as f:
         for job, config in zip(jobs, configs):
@@ -970,7 +1001,7 @@ def check_traj_files(batch, traj_dir) -> bool:
 
 
 @contextmanager
-def new_trainer_context(*, config: Dict[str, Any], args: Namespace):
+def new_trainer_context(*, config: Dict[str, Any], distributed: bool):
     from ocpmodels.common import distutils, gp_utils
     from ocpmodels.common.registry import registry
 
@@ -988,7 +1019,7 @@ def new_trainer_context(*, config: Dict[str, Any], args: Namespace):
     original_config = config
     config = copy.deepcopy(original_config)
 
-    if args.distributed:
+    if distributed:
         distutils.setup(config)
         if config["gp_gpus"] is not None:
             gp_utils.setup_gp(config)
@@ -1029,7 +1060,7 @@ def new_trainer_context(*, config: Dict[str, Any], args: Namespace):
         if distutils.is_master():
             logging.info(f"Total time taken: {time.time() - start_time}")
     finally:
-        if args.distributed:
+        if distributed:
             distutils.cleanup()
 
 


### PR DESCRIPTION
Adds a `train` method to the cli. Updates the [method that creates the `config` dictionary](https://github.com/Open-Catalyst-Project/ocp/pull/575/files#diff-d49941eeb80aee5a28d712edbb457ef26de109848fd6729361a47174e4c38ccbR423) to use these explicitly-provided values rather than an argparse namespace. Training itself is unchanged - only the methods to parameterize the training run are updated.

Most command line arguments are the same. One exception is the method used to override specific values in config.yml. In the past, overriding would have used the specific field as the cli option, e.g. `--optim.batch_size=10`. Now we use a `--config` option, e.g. `--config optim.batch_size=10`; this `--config` option can be used more than once to set multiple values.

## Tests

### 1. Ensure that training can run correcty
```
$ python -m cli.cli train --config-yml configs/s2ef/all/schnet/schnet.yml --debug
2023-09-07 16:29:53 (INFO): Project root: /private/home/kylemichel/src/github.com/open-catalyst-project/ocp
2023-09-07 16:29:57 (INFO): amp: false
cmd:
  checkpoint_dir: ./checkpoints/2023-09-07-16-30-08
  commit: 204b996
  identifier: ''
  logs_dir: ./logs/tensorboard/2023-09-07-16-30-08
  print_every: 10
  results_dir: ./results/2023-09-07-16-30-08
  seed: 0
  timestamp_id: 2023-09-07-16-30-08
dataset:
  grad_target_mean: 0.0
  grad_target_std: 2.887317180633545
  normalize_labels: true
  src: data/s2ef/all/train/
  target_mean: -0.7554450631141663
  target_std: 2.887317180633545
gpus: 0
logger: tensorboard
model: schnet
model_attributes:
  cutoff: 6.0
  hidden_channels: 1024
  num_filters: 256
  num_gaussians: 200
  num_interactions: 5
  use_pbc: true
noddp: false
optim:
  batch_size: 20
  eval_batch_size: 20
  eval_every: 10000
  force_coefficient: 30
  lr_gamma: 0.1
  lr_initial: 0.0001
  lr_milestones:
  - 313907
  - 523179
  - 732451
  max_epochs: 15
  num_workers: 16
  warmup_factor: 0.2
  warmup_steps: 209271
slurm: {}
task:
  dataset: trajectory_lmdb
  description: Regressing to energies and forces for DFT trajectories from OCP
  eval_on_free_atoms: true
  grad_input: atomic forces
  labels:
  - potential energy
  metric: mae
  train_on_free_atoms: true
  type: regression
trainer: forces
val_dataset:
  src: data/s2ef/all/val_id/

2023-09-07 16:30:04 (INFO): Batch balancing is disabled for single GPU training.
2023-09-07 16:30:08 (INFO): Batch balancing is disabled for single GPU training.
2023-09-07 16:30:08 (INFO): Loading dataset: trajectory_lmdb
2023-09-07 16:30:08 (INFO): Loading model: schnet
2023-09-07 16:30:08 (INFO): Loaded SchNetWrap with 9088513 parameters.
2023-09-07 16:31:27 (INFO): forcesx_mae: 2.33e+00, forcesy_mae: 2.54e+00, forcesz_mae: 2.66e+00, forces_mae: 2.51e+00, forces_cos: -7.00e-03, forces_magnitude: 4.94e+00, energy_mae: 9.84e+01, energy_force_within_threshold: 0.00e+00, loss: 1.12e+02, lr: 2.00e-05, epoch: 1.49e-06, step: 1.00e+01
...
2023-09-12 14:00:21 (INFO): forcesx_mae: 5.99e-02, forcesy_mae: 8.79e-02, forcesz_mae: 9.84e-02, forces_mae: 8.20e-02, forces_cos: 8.78e-02, forces_magnitude: 1.38e-01, energy_mae: 2.41e+00, energy_force_within_threshold: 0.00e+00, loss: 3.38e+00, lr: 3.53e-05, epoch: 5.97e-03, step: 4.00e+04
2023-09-12 14:01:03 (INFO): forcesx_mae: 6.22e-02, forcesy_mae: 8.15e-02, forcesz_mae: 7.72e-02, forces_mae: 7.36e-02, forces_cos: 7.74e-02, forces_magnitude: 1.25e-01, energy_mae: 2.32e+00, energy_force_within_threshold: 0.00e+00, loss: 3.12e+00, lr: 3.53e-05, epoch: 5.97e-03, step: 4.00e+04
```

### 2. Ensure that default parameters are the same between old and new code versions

```
# Start a training run with the new code
$ python -m cli.cli train --config-yml configs/s2ef/all/schnet/schnet.yml --debug > new.out

# Start a training run with the old code
$ python main.py --mode train --config-yml configs/s2ef/all/schnet/schnet.yml --debug > old.out

# Check that all settings are the same 
$ diff -y new.out old.out
2023-09-12 15:12:12 (INFO): Project root: /private/home/kylem | 2023-09-12 15:14:49 (INFO): Project root: /private/home/kylem
2023-09-12 15:12:15 (INFO): amp: false                        | 2023-09-12 15:14:52 (INFO): amp: false
cmd:                                                            cmd:
  checkpoint_dir: ./checkpoints/2023-09-12-15-11-12           |   checkpoint_dir: ./checkpoints/2023-09-12-15-15-28
  commit: 8389ed1                                             |   commit: 77c3e88
  identifier: ''                                                  identifier: ''
  logs_dir: ./logs/tensorboard/2023-09-12-15-11-12            |   logs_dir: ./logs/tensorboard/2023-09-12-15-15-28
  print_every: 10                                                 print_every: 10
  results_dir: ./results/2023-09-12-15-11-12                  |   results_dir: ./results/2023-09-12-15-15-28
  seed: 0                                                         seed: 0
  timestamp_id: 2023-09-12-15-11-12                           |   timestamp_id: 2023-09-12-15-15-28
dataset:                                                        dataset:
  grad_target_mean: 0.0                                           grad_target_mean: 0.0
  grad_target_std: 2.887317180633545                              grad_target_std: 2.887317180633545
  normalize_labels: true                                          normalize_labels: true
  src: data/s2ef/all/train/                                       src: data/s2ef/all/train/
  target_mean: -0.7554450631141663                                target_mean: -0.7554450631141663
  target_std: 2.887317180633545                                   target_std: 2.887317180633545
gpus: 0                                                         gpus: 0
logger: tensorboard                                             logger: tensorboard
model: schnet                                                   model: schnet
model_attributes:                                               model_attributes:
  cutoff: 6.0                                                     cutoff: 6.0
  hidden_channels: 1024                                           hidden_channels: 1024
  num_filters: 256                                                num_filters: 256
  num_gaussians: 200                                              num_gaussians: 200
  num_interactions: 5                                             num_interactions: 5
  use_pbc: true                                                   use_pbc: true
noddp: false                                                    noddp: false
optim:                                                          optim:
  batch_size: 20                                                  batch_size: 20
  eval_batch_size: 20                                             eval_batch_size: 20
  eval_every: 10000                                               eval_every: 10000
  force_coefficient: 30                                           force_coefficient: 30
  lr_gamma: 0.1                                                   lr_gamma: 0.1
  lr_initial: 0.0001                                              lr_initial: 0.0001
  lr_milestones:                                                  lr_milestones:
  - 313907                                                        - 313907
  - 523179                                                        - 523179
  - 732451                                                        - 732451
  max_epochs: 15                                                  max_epochs: 15
  num_workers: 16                                                 num_workers: 16
  warmup_factor: 0.2                                              warmup_factor: 0.2
  warmup_steps: 209271                                            warmup_steps: 209271
slurm: {}                                                       slurm: {}
task:                                                           task:
  dataset: trajectory_lmdb                                        dataset: trajectory_lmdb
  description: Regressing to energies and forces for DFT traj     description: Regressing to energies and forces for DFT traj
  eval_on_free_atoms: true                                        eval_on_free_atoms: true
  grad_input: atomic forces                                       grad_input: atomic forces
  labels:                                                         labels:
  - potential energy                                              - potential energy
  metric: mae                                                     metric: mae
  train_on_free_atoms: true                                       train_on_free_atoms: true
  type: regression                                                type: regression
trainer: forces                                                 trainer: forces
val_dataset:                                                    val_dataset:
  src: data/s2ef/all/val_id/                                      src: data/s2ef/all/val_id/
```

### 3. Ensure that overridden parameters are the same between old and new code versions

```
# Start a training run with the new code
$ python -m cli.cli train --config-yml configs/s2ef/all/schnet/schnet.yml --checkpoint-path path/to/checkpoint --config optim.batch_size=10 --run-dir path/to/run --identifier run_id --seed 1 --debug --amp --num-nodes 2 --num-gpus 3 --cpu --distributed-backend ucc --distributed-port 200 --gp-gpus 4 --local-rank 1 --logdir path/to/logs --timestamp-id tid --print-every 15 > new.out

# Start a training run with the old code
$ python main.py --mode=train --config-yml=configs/s2ef/all/schnet/schnet.yml --checkpoint-path=path/to/checkpoint --optim.batch_size=10 --run-dir=path/to/run --identifier=run_id --seed=1 --debug --amp --num-nodes=2 --num-gpus=3 --cpu --distributed-backend=ucc --distributed-port=200 --gp-gpus=4 --local-rank=1 --logdir=path/to/logs --timestamp-id=tid --print-every=15 > old.out

# Check that all settings are the same 
$ diff -y new.out old.out
2023-09-12 15:55:19 (INFO): Project root: /private/home/kylem | 2023-09-12 15:56:22 (INFO): Project root: /private/home/kylem
2023-09-12 15:55:23 (INFO): amp: true                         | 2023-09-12 15:56:25 (INFO): amp: true
cmd:                                                            cmd:
  checkpoint_dir: path/to/run/checkpoints/tid                     checkpoint_dir: path/to/run/checkpoints/tid
  commit: 627e497                                             |   commit: 77c3e88
  identifier: run_id                                              identifier: run_id
  logs_dir: path/to/run/logs/tensorboard/tid                      logs_dir: path/to/run/logs/tensorboard/tid
  print_every: 15                                                 print_every: 15
  results_dir: path/to/run/results/tid                            results_dir: path/to/run/results/tid
  seed: 1                                                         seed: 1
  timestamp_id: tid                                               timestamp_id: tid
dataset:                                                        dataset:
  grad_target_mean: 0.0                                           grad_target_mean: 0.0
  grad_target_std: 2.887317180633545                              grad_target_std: 2.887317180633545
  normalize_labels: true                                          normalize_labels: true
  src: data/s2ef/all/train/                                       src: data/s2ef/all/train/
  target_mean: -0.7554450631141663                                target_mean: -0.7554450631141663
  target_std: 2.887317180633545                                   target_std: 2.887317180633545
gpus: 0                                                         gpus: 0
logger: tensorboard                                             logger: tensorboard
model: schnet                                                   model: schnet
model_attributes:                                               model_attributes:
  cutoff: 6.0                                                     cutoff: 6.0
  hidden_channels: 1024                                           hidden_channels: 1024
  num_filters: 256                                                num_filters: 256
  num_gaussians: 200                                              num_gaussians: 200
  num_interactions: 5                                             num_interactions: 5
  use_pbc: true                                                   use_pbc: true
noddp: false                                                    noddp: false
optim:                                                          optim:
  batch_size: 10                                                  batch_size: 10
  eval_batch_size: 20                                             eval_batch_size: 20
  eval_every: 10000                                               eval_every: 10000
  force_coefficient: 30                                           force_coefficient: 30
  lr_gamma: 0.1                                                   lr_gamma: 0.1
  lr_initial: 0.0001                                              lr_initial: 0.0001
  lr_milestones:                                                  lr_milestones:
  - 313907                                                        - 313907
  - 523179                                                        - 523179
  - 732451                                                        - 732451
  max_epochs: 15                                                  max_epochs: 15
  num_workers: 16                                                 num_workers: 16
  warmup_factor: 0.2                                              warmup_factor: 0.2
  warmup_steps: 209271                                            warmup_steps: 209271
slurm: {}                                                       slurm: {}
task:                                                           task:
  dataset: trajectory_lmdb                                        dataset: trajectory_lmdb
  description: Regressing to energies and forces for DFT traj     description: Regressing to energies and forces for DFT traj
  eval_on_free_atoms: true                                        eval_on_free_atoms: true
  grad_input: atomic forces                                       grad_input: atomic forces
  labels:                                                         labels:
  - potential energy                                              - potential energy
  metric: mae                                                     metric: mae
  train_on_free_atoms: true                                       train_on_free_atoms: true
  type: regression                                                type: regression
trainer: forces                                                 trainer: forces
val_dataset:                                                    val_dataset:
  src: data/s2ef/all/val_id/                                      src: data/s2ef/all/val_id/
```