### PR TITLE
Adds optional per-element linear reference coefficients to EquiformerV2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,6 @@ commands:
               # Conda configuration
               conda config --set always_yes yes --set auto_update_conda false
               # Update conda
-              conda update conda
               conda install mamba -n base -c conda-forge
               # Install ocp conda env
               conda create --name ocp-models --clone base

--- a/ocpmodels/datasets/oc22_lmdb_dataset.py
+++ b/ocpmodels/datasets/oc22_lmdb_dataset.py
@@ -159,9 +159,9 @@ class OC22LmdbDataset(Dataset):
                 fid = fid.item()
                 data_object.fid = fid
 
-        if hasattr(data_object, "y_relaxed"):
+        if getattr(data_object, "y_relaxed", None) is not None:
             attr = "y_relaxed"
-        elif hasattr(data_object, "y"):
+        elif getattr(data_object, "y", None) is not None:
             attr = "y"
         # if targets are not available, test data is being used
         else:

--- a/ocpmodels/models/equiformer_v2/equiformer_v2_oc20.py
+++ b/ocpmodels/models/equiformer_v2/equiformer_v2_oc20.py
@@ -512,6 +512,20 @@ class EquiformerV2_OC20(BaseModel):
 
         # Add the per-atom linear references to the energy.
         if self.use_energy_lin_ref and self.load_energy_lin_ref:
+            # During training, target E = (E_DFT - E_ref - E_mean) / E_std, and
+            # during inference, \hat{E_DFT} = \hat{E} * E_std + E_ref + E_mean
+            # where
+            #
+            # E_DFT = raw DFT energy,
+            # E_ref = reference energy,
+            # E_mean = normalizer mean,
+            # E_std = normalizer std,
+            # \hat{E} = predicted energy,
+            # \hat{E_DFT} = predicted DFT energy.
+            #
+            # We can also write this as
+            # \hat{E_DFT} = E_std * (\hat{E} + E_ref / E_std) + E_mean,
+            # which is why we save E_ref / E_std as the linear reference.
             energy.index_add_(
                 0,
                 data.batch,

--- a/ocpmodels/models/equiformer_v2/equiformer_v2_oc20.py
+++ b/ocpmodels/models/equiformer_v2/equiformer_v2_oc20.py
@@ -526,11 +526,12 @@ class EquiformerV2_OC20(BaseModel):
             # We can also write this as
             # \hat{E_DFT} = E_std * (\hat{E} + E_ref / E_std) + E_mean,
             # which is why we save E_ref / E_std as the linear reference.
-            energy.index_add_(
-                0,
-                data.batch,
-                self.energy_lin_ref[atomic_numbers].to(node_energy.dtype),
-            )
+            with torch.cuda.amp.autocast(False):
+                energy = energy.to(self.energy_lin_ref.dtype).index_add(
+                    0,
+                    data.batch,
+                    self.energy_lin_ref[atomic_numbers],
+                )
 
         ###############################################################
         # Force estimation

--- a/ocpmodels/models/equiformer_v2/equiformer_v2_oc20.py
+++ b/ocpmodels/models/equiformer_v2/equiformer_v2_oc20.py
@@ -96,6 +96,15 @@ class EquiformerV2_OC20(BaseModel):
 
         weight_init (str):          ['normal', 'uniform'] initialization of weights of linear layers except those in radial functions
         enforce_max_neighbors_strictly (bool):      When edges are subselected based on the `max_neighbors` arg, arbitrarily select amongst equidistant / degenerate edges to have exactly the correct number.
+        avg_num_nodes (float):      Average number of nodes per graph
+        avg_degree (float):         Average degree of nodes in the graph
+
+        use_energy_lin_ref (bool):  Whether to add the per-atom energy references during prediction.
+                                    During training and validation, this should be kept `False` since we use the `lin_ref` parameter in the OC22 dataloader to subtract the per-atom linear references from the energy targets.
+                                    During prediction (where we don't have energy targets), this can be set to `True` to add the per-atom linear references to the predicted energies.
+        load_energy_lin_ref (bool): Whether to add nn.Parameters for the per-element energy references.
+                                    This additional flag is there to ensure compatibility when strict-loading checkpoints, since the `use_energy_lin_ref` flag can be either True or False even if the model is trained with linear references.
+                                    You can't have use_energy_lin_ref = True and load_energy_lin_ref = False, since the model will not have the parameters for the linear references. All other combinations are fine.
     """
 
     def __init__(
@@ -141,6 +150,8 @@ class EquiformerV2_OC20(BaseModel):
         enforce_max_neighbors_strictly: bool = True,
         avg_num_nodes: Optional[float] = None,
         avg_degree: Optional[float] = None,
+        use_energy_lin_ref: Optional[bool] = False,
+        load_energy_lin_ref: Optional[bool] = False,
     ):
         super().__init__()
 
@@ -201,6 +212,12 @@ class EquiformerV2_OC20(BaseModel):
 
         self.avg_num_nodes = avg_num_nodes or _AVG_NUM_NODES
         self.avg_degree = avg_degree or _AVG_DEGREE
+
+        self.use_energy_lin_ref = use_energy_lin_ref
+        self.load_energy_lin_ref = load_energy_lin_ref
+        assert not (
+            self.use_energy_lin_ref and not self.load_energy_lin_ref
+        ), "You can't have use_energy_lin_ref = True and load_energy_lin_ref = False, since the model will not have the parameters for the linear references. All other combinations are fine."
 
         self.weight_init = weight_init
         assert self.weight_init in ["normal", "uniform"]
@@ -371,6 +388,12 @@ class EquiformerV2_OC20(BaseModel):
                 alpha_drop=0.0,
             )
 
+        if self.load_energy_lin_ref:
+            self.energy_lin_ref = nn.Parameter(
+                torch.zeros(self.max_num_elements),
+                requires_grad=False,
+            )
+
         self.apply(self._init_weights)
         self.apply(self._uniform_init_rad_func_linear_weights)
 
@@ -486,6 +509,14 @@ class EquiformerV2_OC20(BaseModel):
         )
         energy.index_add_(0, data.batch, node_energy.view(-1))
         energy = energy / self.avg_num_nodes
+
+        # Add the per-atom linear references to the energy.
+        if self.use_energy_lin_ref and self.load_energy_lin_ref:
+            energy.index_add_(
+                0,
+                data.batch,
+                self.energy_lin_ref[atomic_numbers].to(node_energy.dtype),
+            )
 
         ###############################################################
         # Force estimation


### PR DESCRIPTION
This is primarily to support the latest EquiformerV2 models we've been training on OC22 (#577), that use per-element linear references.

During training and validation, these references are subtracted off the energy targets as usual in the OC22 dataloader. But during testing and prediction, these references need to be added to the model's energy prediction. The latter is currently unsupported in the codebase.

There are a few different options of how to go about this:
1. We could re-use the coefficients from the dataloader by adding additional logic to the `predict` function in the trainer, but that makes invoking these models through the ASE calculator tricky since in that workflow there typically isn't a dataloader.
2. There's a similar issue if we add a path to the coefficients numpy file in the config yaml, since the ASE calculator workflow might directly load checkpoints (without a config yaml).
3. We could package these as part of the model's `state_dict`. This seems like the most failproof and the one I went with, but does add a couple of flags to the model that one has to be careful about:
- `use_energy_lin_ref`: Whether to add the per-atom energy references during energy prediction,
- `load_energy_lin_ref`: Whether to create the nn.Parameters object for the per-element energy coefficients.

If the model ships with these coefficients in the state_dict, then `load_energy_lin_ref` would have to be set to True, otherwise checkpoint loading will fail. It's still possible to set `use_energy_lin_ref` to False even with `load_energy_lin_ref = True` for training / validation purposes.

Open to suggestions!