### PR TITLE
DDEC release and IS2RS clarification for ODAC23

### DIFF
--- a/DATASET.md
+++ b/DATASET.md
@@ -496,6 +496,16 @@ For IS2RE / IS2RS training, validation and test sets, we provide precomputed LMD
 |Train + Validation + Test (all splits)    |  809M | 2.2G |  [f7f2f58669a30abae8cb9ba1b7f2bcd2](https://dl.fbaipublicfiles.com/dac/datasets/odac23_is2r.tar.gz )  |
 |    |    |    |    |
 
+### DDEC Charges
+
+We provide DDEC charges computed for all MOFs in the ODAC23 dataset. A small number of MOFs (~2%) are missing these charges because the DDEC calcuations failed for them.
+
+|Size of compressed version (in bytes)    |Size of uncompressed version (in bytes)    | MD5 checksum (download link)    |
+|---    |---    |---    |
+|  147M | 534M |  [81927b78d9e4184cc3c398e79760126a](https://dl.fbaipublicfiles.com/dac/datasets/ddec.tar.gz )  |
+|    |    |    |
+
+
 ### Citing ODAC23
 
 The OpenDAC 2023 (ODAC23) dataset is licensed under a [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/MODELS.md
+++ b/MODELS.md
@@ -159,6 +159,12 @@ OC22 dataset or pretrained models, as well as the original paper for each model:
 |eSCN (Direct) | [checkpoint](https://dl.fbaipublicfiles.com/dac/checkpoints_20231018/eSCN_Direct.pt) | [config](https://github.com/Open-Catalyst-Project/ocp/tree/main/configs/odac/is2re/eSCN.yml) |
 |EquiformerV2 (Direct) | [checkpoint](https://dl.fbaipublicfiles.com/dac/checkpoints_20231018/Equiformer_V2_Direct.pt) | [config](https://github.com/Open-Catalyst-Project/ocp/tree/main/configs/odac/is2re/eqv2_31M.yml) |
 
+The models in the table above were trained to predict relaxed energy directly. Relaxed energies can also be predicted by running structural relaxations using the S2EF models from the previous section.
+
+## IS2RS
+
+The IS2RS is solved by running structural relaxations using the S2EF models from the prior section.
+
 The Open DAC 2023 (ODAC23) dataset is licensed under a [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 Please consider citing the following paper in any research manuscript using the ODAC23 dataset:


### PR DESCRIPTION
Released DDEC charges per external request (https://github.com/Open-Catalyst-Project/ocp/issues/601) and added a note clarifying reg relaxations for IS2RS and IS2RE (https://github.com/Open-Catalyst-Project/ocp/issues/600).