### PR TITLE
Add in tests for coefficient mapping, mprimary, lprimary

### DIFF
--- a/tests/models/test_equiformer_v2.py
+++ b/tests/models/test_equiformer_v2.py
@@ -16,6 +16,10 @@ from ase.io import read
 from ocpmodels.common.registry import registry
 from ocpmodels.common.utils import load_state_dict, setup_imports
 from ocpmodels.datasets import data_list_collater
+from ocpmodels.models.equiformer_v2.so3 import (
+    CoefficientMappingModule,
+    SO3_Embedding,
+)
 from ocpmodels.preprocessing import AtomsToGraphs
 
 
@@ -117,3 +121,74 @@ class TestEquiformerV2:
 
         assert snapshot == forces.shape
         assert snapshot == pytest.approx(forces.detach().mean(0))
+
+
+class TestMPrimaryLPrimary:
+    def test_mprimary_lprimary_mappings(self):
+        def sign(x):
+            return 1 if x >= 0 else -1
+
+        device = torch.device("cpu")
+        lmax_list = [6, 8]
+        mmax_list = [3, 6]
+        for lmax in lmax_list:
+            for mmax in mmax_list:
+                c = CoefficientMappingModule([lmax], [mmax])
+
+                embedding = SO3_Embedding(
+                    length=1,
+                    lmax_list=[lmax],
+                    num_channels=1,
+                    device=device,
+                    dtype=torch.float32,
+                )
+
+                """
+                Generate L_primary matrix
+                L0: 0.00 ~ L0M0
+                L1: -1.01 1.00 1.01 ~ L1M(-1),L1M0,L1M1
+                L2: -2.02 -2.01 2.00 2.01 2.02 ~ L2M(-2),L2M(-1),L2M0,L2M1,L2M2
+                """
+                test_matrix_lp = []
+                for l in range(lmax + 1):
+                    max_m = min(l, mmax)
+                    for m in range(-max_m, max_m + 1):
+                        v = l * sign(m) + 0.01 * m  # +/- l . 00 m
+                        test_matrix_lp.append(v)
+
+                test_matrix_lp = (
+                    torch.tensor(test_matrix_lp)
+                    .reshape(1, -1, 1)
+                    .to(torch.float32)
+                )
+
+                """
+                Generate M_primary matrix
+                M0: 0.00 , 1.00, 2.00, ... , LMax ~ M0L0, M0L1, .., M0L(LMax)
+                M1: 1.01, 2.01, .., LMax.01, -1.01, -2.01, -LMax.01 ~ L1M1, L2M1, .., L(LMax)M1, L1M(-1), L2M(-1), ... , L(LMax)M(-1)
+                """
+                test_matrix_mp = []
+                for m in range(max_m + 1):
+                    for l in range(m, lmax + 1):
+                        v = l + 0.01 * m  # +/- l . 00 m
+                        test_matrix_mp.append(v)
+                    if m > 0:
+                        for l in range(m, lmax + 1):
+                            v = -(l + 0.01 * m)  # +/- l . 00 m
+                            test_matrix_mp.append(v)
+
+                test_matrix_mp = (
+                    torch.tensor(test_matrix_mp)
+                    .reshape(1, -1, 1)
+                    .to(torch.float32)
+                )
+
+                embedding.embedding = test_matrix_lp.clone()
+
+                embedding._m_primary(c)
+                mp = embedding.embedding.clone()
+                (test_matrix_mp == mp).all()
+
+                embedding._l_primary(c)
+                lp = embedding.embedding.clone()
+                (test_matrix_lp == lp).all()

--- a/tests/models/test_escn.py
+++ b/tests/models/test_escn.py
@@ -1,0 +1,75 @@
+import torch
+
+from ocpmodels.models.escn.so3 import CoefficientMapping
+from ocpmodels.models.escn.so3 import SO3_Embedding as escn_SO3_Embedding
+
+
+class TestMPrimaryLPrimary:
+    def test_mprimary_lprimary_mappings(self):
+        def sign(x):
+            return 1 if x >= 0 else -1
+
+        device = torch.device("cpu")
+        lmax_list = [6, 8]
+        mmax_list = [3, 6]
+        for lmax in lmax_list:
+            for mmax in mmax_list:
+                c = CoefficientMapping([lmax], [mmax], device=device)
+
+                escn_embedding = escn_SO3_Embedding(
+                    length=1,
+                    lmax_list=[lmax],
+                    num_channels=1,
+                    device=device,
+                    dtype=torch.float32,
+                )
+
+                """
+                Generate L_primary matrix
+                L0: 0.00 ~ L0M0
+                L1: -1.01 1.00 1.01 ~ L1M(-1),L1M0,L1M1
+                L2: -2.02 -2.01 2.00 2.01 2.02 ~ L2M(-2),L2M(-1),L2M0,L2M1,L2M2
+                """
+                test_matrix_lp = []
+                for l in range(lmax + 1):
+                    max_m = min(l, mmax)
+                    for m in range(-max_m, max_m + 1):
+                        v = l * sign(m) + 0.01 * m  # +/- l . 00 m
+                        test_matrix_lp.append(v)
+
+                test_matrix_lp = (
+                    torch.tensor(test_matrix_lp)
+                    .reshape(1, -1, 1)
+                    .to(torch.float32)
+                )
+
+                """
+                Generate M_primary matrix
+                M0: 0.00 , 1.00, 2.00, ... , LMax ~ M0L0, M0L1, .., M0L(LMax)
+                M1: 1.01, 2.01, .., LMax.01, -1.01, -2.01, -LMax.01 ~ L1M1, L2M1, .., L(LMax)M1, L1M(-1), L2M(-1), ... , L(LMax)M(-1)
+                """
+                test_matrix_mp = []
+                for m in range(max_m + 1):
+                    for l in range(m, lmax + 1):
+                        v = l + 0.01 * m  # +/- l . 00 m
+                        test_matrix_mp.append(v)
+                    if m > 0:
+                        for l in range(m, lmax + 1):
+                            v = -(l + 0.01 * m)  # +/- l . 00 m
+                            test_matrix_mp.append(v)
+
+                test_matrix_mp = (
+                    torch.tensor(test_matrix_mp)
+                    .reshape(1, -1, 1)
+                    .to(torch.float32)
+                )
+
+                escn_embedding.embedding = test_matrix_lp.clone()
+
+                escn_embedding._m_primary(c)
+                mp = escn_embedding.embedding.clone()
+                (test_matrix_mp == mp).all()
+
+                escn_embedding._l_primary(c)
+                lp = escn_embedding.embedding.clone()
+                (test_matrix_lp == lp).all()


### PR DESCRIPTION
Inside the two different SO3 embedding classes for eSCN / Equiformer there are two permutation transformations that permute coefficients to be L or M primary (_l_primary, _m_primary). This adds two tests to make sure these permutation matrices work as expected. 

L primary format coefficients should appear in the order
L0M0, L1M-1, L1M0, L1M1, L2M-2, ...

M primary format coefficients should appear in the order
M0L0, M0L1,..., M0Lmax, followed by
M1L1, M1L2, ..., M1Lmax, followed by
M(-1)L1, M(-1)L2, ... , M(-1)Lmax ...

A coefficient test matrix where the value of the coefficients has a 1 to 1 mapping with its LM values. 

The mapping is as follows
1.01 -> L=1, M=1
1.02 -> L=1, M=2
-1.01 -> L=1, M=-1
0.0 -> L=0, M=0
-3.04 -> L=3, M=-4

After permuting the matrix the coefficients are verified to be correct positions.
