### PR TITLE
bump miniconda version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
           name: Install conda and environment
           command: |
             if [ ! -d "/home/circleci/miniconda" ]; then
-              wget https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-Linux-x86_64.sh -O miniconda.sh
+              wget https://repo.anaconda.com/miniconda/Miniconda3-py39_23.11.0-2-Linux-x86_64.sh -O miniconda.sh
               bash miniconda.sh -b -p "$HOME"/miniconda
               source /home/circleci/miniconda/etc/profile.d/conda.sh
               conda activate base


### PR DESCRIPTION
Previous version started to fail CI, https://app.circleci.com/pipelines/github/Open-Catalyst-Project/ocp/2032/workflows/b691e1ab-2cd5-43b8-b017-f2c2ccff91ef/jobs/4097 , unclear why but bumping miniconda version fixes this