### PR TITLE
change _compute_metrics not to modify callers version

### DIFF
--- a/ocpmodels/trainers/ocp_trainer.py
+++ b/ocpmodels/trainers/ocp_trainer.py
@@ -360,6 +360,10 @@ class OCPTrainer(BaseTrainer):
         return loss
 
     def _compute_metrics(self, out, batch, evaluator, metrics={}):
+        # this function changes the values in the out dictionary,
+        # make a copy instead of changing them in the callers version
+        out = {k: v.clone() for k, v in out.items()}
+
         natoms = batch.natoms
         batch_size = natoms.numel()
 


### PR DESCRIPTION
Currently the function _compute_metrics() takes as input a dictionary (out) that contains tensors as values. These values are modified inside of _compute_metrics() , which means the callers version of these tensors are also modified. 

```
out=forward(batch)
_compute_metrics(out)
out # no longer the same values as from forward(batch)
```