### PR TITLE
add unique key loader check to YAML to avoid problematic configs

### DIFF
--- a/tests/common/test_yaml_loader.py
+++ b/tests/common/test_yaml_loader.py
@@ -1,0 +1,45 @@
+import tempfile
+
+import pytest
+import yaml
+
+from ocpmodels.common.utils import UniqueKeyLoader
+
+
+@pytest.fixture(scope="class")
+def invalid_yaml_config():
+    return """
+key1:
+    - a
+    - b
+key1:
+    - c
+    - d
+"""
+
+
+@pytest.fixture(scope="class")
+def valid_yaml_config():
+    return """
+key1:
+    - a
+    - b
+key2:
+    - c
+    - d
+"""
+
+
+def test_invalid_config(invalid_yaml_config):
+    with tempfile.NamedTemporaryFile(delete=False) as fp:
+        fp.write(invalid_yaml_config.encode())
+        fp.close()
+        with pytest.raises(ValueError):
+            yaml.load(open(fp.name, "r"), Loader=UniqueKeyLoader)
+
+
+def test_valid_config(valid_yaml_config):
+    with tempfile.NamedTemporaryFile(delete=False) as fp:
+        fp.write(valid_yaml_config.encode())
+        fp.close()
+        yaml.load(open(fp.name, "r"), Loader=UniqueKeyLoader)


### PR DESCRIPTION
If you specify the same key in a config the current default behavior is to overwrite the value of the key with latest entry. For example something like, 

```
key1: 
  - a 
key1:
  - b
```

Would result a dictionary 
```
d={'key1':'b'}
```

This commit throws an error when such a situation occurs. This can prevent a user from accidentally specifying a value twice in a config that is not actually being used (overwritten by last entry).